### PR TITLE
perf(core): optimize per_event rounding to touched asset/bucket

### DIFF
--- a/eupholio-core/doc/12-dev-workflows.md
+++ b/eupholio-core/doc/12-dev-workflows.md
@@ -1,0 +1,55 @@
+# 12. Practical Dev Workflows
+
+This note captures reusable loops for day-to-day core development and PR review in this repository.
+
+## eupholio-core-dev loop
+
+Use this for normal feature/fix work inside `eupholio-core`.
+
+1. **Sync and branch**
+   - `git fetch origin`
+   - `git switch <base>`
+   - `git pull --ff-only`
+   - `git switch -c <topic-branch>`
+2. **Implement in small commits**
+   - Prefer one concern per commit (logic, tests, docs).
+3. **Run focused checks first**
+   - `cd eupholio-core && cargo test --all-targets`
+4. **Run repo-level checks before PR**
+   - `go test ./...`
+   - `go test ./test/integration/...`
+   - `scripts/check_validation_codes.py`
+   - `scripts/compare_go_rust.py`
+5. **Prepare PR**
+   - Rebase on latest base branch.
+   - Keep PR body short: motivation, change summary, validation run.
+
+## github-pr-review-loop
+
+Use this when addressing review comments quickly and safely.
+
+1. **Triage comments**
+   - Group comments into: must-fix, optional, clarification-only.
+2. **Patch by group**
+   - Apply related changes together so each commit has a clear intent.
+3. **Re-run impacted checks only, then full required set**
+   - Start with nearby tests, then run mandatory checks from `AGENTS.md`.
+4. **Reply with evidence**
+   - For each resolved thread, reference exactly what changed and where.
+5. **Final pass**
+   - `git diff --stat origin/<base>...HEAD`
+   - Confirm docs/fixtures stayed aligned with behavior changes.
+
+## Quick commands
+
+```bash
+# core-only checks
+cd eupholio-core
+cargo test --all-targets
+
+# full mandatory checks from repo root
+go test ./...
+go test ./test/integration/...
+scripts/check_validation_codes.py
+scripts/compare_go_rust.py
+```

--- a/eupholio-core/doc/README.md
+++ b/eupholio-core/doc/README.md
@@ -24,3 +24,7 @@ This directory contains design and operational documentation for `eupholio-core`
   - List of issue codes returned by `validate`
 - [10-pr-prep-core-rs.md](./10-pr-prep-core-rs.md)
   - PR preparation notes for merging core-rs into main
+- [11-pr-ready-summary-core-rs.md](./11-pr-ready-summary-core-rs.md)
+  - Collected summary for PR readiness checkpoints
+- [12-dev-workflows.md](./12-dev-workflows.md)
+  - Reusable development and review loops

--- a/eupholio-core/tests/per_event_rounding_regression.rs
+++ b/eupholio-core/tests/per_event_rounding_regression.rs
@@ -1,0 +1,126 @@
+use std::collections::HashMap;
+
+use chrono::{TimeZone, Utc};
+use eupholio_core::{
+    calculate, calculate_total_average_with_carry_and_rounding,
+    config::{Config, CostMethod, RoundingMode, RoundingPolicy, RoundingTiming},
+    event::Event,
+    report::CarryIn,
+};
+use rust_decimal_macros::dec;
+
+fn ts(y: i32, m: u32, d: u32) -> chrono::DateTime<Utc> {
+    Utc.with_ymd_and_hms(y, m, d, 0, 0, 0).unwrap()
+}
+
+#[test]
+fn per_event_total_average_rounds_carry_in_before_first_touch() {
+    let events = vec![
+        Event::Acquire {
+            id: "eth-a1".into(),
+            asset: "ETH".into(),
+            qty: dec!(1),
+            jpy_cost: dec!(100),
+            ts: ts(2026, 1, 1),
+        },
+        Event::Dispose {
+            id: "btc-d1".into(),
+            asset: "BTC".into(),
+            qty: dec!(1),
+            jpy_proceeds: dec!(102),
+            ts: ts(2026, 1, 2),
+        },
+    ];
+
+    let mut carry_in = HashMap::new();
+    carry_in.insert(
+        "BTC".to_string(),
+        CarryIn {
+            qty: dec!(1.004),
+            cost: dec!(100.6),
+        },
+    );
+
+    let report = calculate_total_average_with_carry_and_rounding(
+        2026,
+        &events,
+        &carry_in,
+        RoundingPolicy {
+            quantity: eupholio_core::config::RoundRule {
+                scale: 2,
+                mode: RoundingMode::HalfUp,
+            },
+            unit_price: eupholio_core::config::RoundRule {
+                scale: 2,
+                mode: RoundingMode::HalfUp,
+            },
+            currency: HashMap::from([(
+                "JPY".to_string(),
+                eupholio_core::config::RoundRule {
+                    scale: 0,
+                    mode: RoundingMode::HalfUp,
+                },
+            )]),
+            timing: RoundingTiming::PerEvent,
+        },
+    );
+
+    // carry_in is rounded first: qty=1.00, cost=101, then dispose 1 @102 => pnl=1
+    assert_eq!(report.realized_pnl_jpy, dec!(1));
+}
+
+#[test]
+fn per_event_moving_average_still_rounds_realized_and_income() {
+    let events = vec![
+        Event::Acquire {
+            id: "a1".into(),
+            asset: "BTC".into(),
+            qty: dec!(1),
+            jpy_cost: dec!(100),
+            ts: ts(2026, 1, 1),
+        },
+        Event::Dispose {
+            id: "d1".into(),
+            asset: "BTC".into(),
+            qty: dec!(1),
+            jpy_proceeds: dec!(100.6),
+            ts: ts(2026, 1, 2),
+        },
+        Event::Income {
+            id: "i1".into(),
+            asset: "ETH".into(),
+            qty: dec!(1),
+            jpy_value: dec!(200.6),
+            ts: ts(2026, 1, 3),
+        },
+    ];
+
+    let report = calculate(
+        Config {
+            method: CostMethod::MovingAverage,
+            tax_year: 2026,
+            rounding: RoundingPolicy {
+                quantity: eupholio_core::config::RoundRule {
+                    scale: 2,
+                    mode: RoundingMode::HalfUp,
+                },
+                unit_price: eupholio_core::config::RoundRule {
+                    scale: 2,
+                    mode: RoundingMode::HalfUp,
+                },
+                currency: HashMap::from([(
+                    "JPY".to_string(),
+                    eupholio_core::config::RoundRule {
+                        scale: 0,
+                        mode: RoundingMode::HalfUp,
+                    },
+                )]),
+                timing: RoundingTiming::PerEvent,
+            },
+        },
+        &events,
+    );
+
+    assert_eq!(report.realized_pnl_jpy, dec!(1));
+    assert_eq!(report.income_jpy, dec!(201));
+}


### PR DESCRIPTION
## Summary
- optimize `moving_average` per-event rounding to round only the touched asset position and only touched JPY accumulators (realized/income)
- optimize `total_average` per-event rounding to round only the touched asset bucket and touched income bucket
- preserve carry-in per-event behavior by rounding carry-in fields once at initialization when per-event timing is used
- add regression tests for per-event carry-in/rounding behavior
- add reusable dev docs (`eupholio-core-dev` and `github-pr-review-loop`)

## Validation
- Could not run local checks in this environment (`cargo`/`go` are unavailable in PATH).