### PR TITLE
docs: add PR watchdog/autofix skill playbooks

### DIFF
--- a/.github/instructions/review-guidelines.instructions.md
+++ b/.github/instructions/review-guidelines.instructions.md
@@ -1,0 +1,40 @@
+# Copilot Review Instructions (eupholio)
+
+Focus review quality on accounting-core safety, deterministic behavior, and CI guardrails.
+
+## Priority review areas
+
+1. **Rounding behavior correctness**
+   - `report_only`, `per_event`, `per_year` semantics must remain explicit and deterministic.
+   - `moving_average + per_year` is intentionally unsupported and should not silently degrade.
+
+2. **Validation code stability**
+   - Validation codes are treated as stable machine-facing identifiers.
+   - Any add/remove/rename must be reflected in `eupholio-core/doc/09-validation-codes.md`.
+
+3. **Parity and reproducibility**
+   - Go/Rust parity scripts and fixtures must remain CI-portable (no machine-local hardcoded paths).
+   - Prefer deterministic fixture inputs and explicit expectations.
+
+4. **Year handling policy**
+   - Out-of-tax-year events should be handled consistently across methods.
+
+## What to deprioritize
+
+- Pure style suggestions that do not improve safety, correctness, portability, or maintainability.
+- Suggestions that introduce broad semantic changes without tests.
+
+## Expected evidence in suggestions
+
+When suggesting logic changes, include at least one of:
+- affected files/functions
+- concrete failure mode
+- test/fixture to add or update
+
+## Project-specific references
+
+- `eupholio-core/doc/04-cli.md`
+- `eupholio-core/doc/07-rounding-policy.md`
+- `eupholio-core/doc/09-validation-codes.md`
+- `scripts/compare_go_rust.py`
+- `scripts/check_validation_codes.py`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,11 @@
 
 Scope: this file applies to the whole repository.
 
-## Branch workflow (core-rs track)
-- Base branch for Rust core work: `core-rs`.
-- Create feature branches from `core-rs` (`feat/...`, `fix/...`, `docs/...`).
+## Branch workflow
+- Base branch: `main`.
+- Create feature branches from `main` (`feat/...`, `fix/...`, `docs/...`, `perf/...`).
 - Keep PRs small and focused (logic vs docs vs fixtures/scripts when possible).
-- Before opening/updating a PR, rebase on latest `core-rs` and rerun required checks.
+- Before opening/updating a PR, rebase on latest `main` and rerun required checks.
 
 ## Mandatory checks before PR
 Run from repo root unless noted:
@@ -36,7 +36,7 @@ Update the relevant docs in the same PR:
 - If docs list changes, refresh index links in `eupholio-core/doc/README.md`
 
 ## PR checklist
-- [ ] Scope is focused and branch targets `core-rs`
+- [ ] Scope is focused and branch targets `main`
 - [ ] Mandatory checks all pass locally
 - [ ] Fixtures/golden tests updated for behavior changes
 - [ ] Go↔Rust parity checked (`scripts/compare_go_rust.py`)

--- a/skills/pr-autofix-safe/SKILL.md
+++ b/skills/pr-autofix-safe/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: pr-autofix-safe
+description: Apply safe, low-risk fixes for GitHub PR review comments and resolve threads automatically. Use for typos, dead code removal, import/order cleanup, non-semantic docs updates, and tooling-path portability fixes; avoid semantic calculation changes without approval.
+---
+
+# PR Autofix (Safe)
+
+Apply only low-risk fixes, push, and resolve threads.
+
+## Allowed Auto-Fix Scope
+
+- Typos and naming cleanup
+- Import ordering / formatting nits
+- Dead code removal
+- Documentation wording/sync fixes
+- Script portability improvements (e.g., configurable binary path)
+
+## Blocked Scope (Require Human Approval)
+
+- Changes to tax/cost calculation semantics
+- Rounding policy behavior changes
+- Data model / API contract changes
+- Performance trade-off changes that alter algorithmic behavior
+
+## Workflow
+
+1. Fetch PR comments and unresolved threads.
+2. Classify each comment (`safe` or `needs-human`).
+3. If no safe items, stop and report.
+4. Implement safe fixes in minimal commits.
+5. Run relevant tests/checks for touched area.
+6. Push branch.
+7. Resolve only threads directly addressed by the commit.
+8. Report:
+   - commit hash(es)
+   - resolved thread ids/links
+   - remaining `needs-human` items
+
+## Guardrails
+
+- Prefer smallest possible patch.
+- Do not batch unrelated fixes in one commit.
+- If uncertain whether semantic impact exists, escalate to `needs-human`.

--- a/skills/pr-watchdog/SKILL.md
+++ b/skills/pr-watchdog/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: pr-watchdog
+description: Monitor a GitHub pull request continuously using gh CLI. Use when you need to check CI/check-runs status, collect new review comments, detect unresolved threads, and report actionable deltas without reprocessing old items.
+---
+
+# PR Watchdog
+
+Monitor one PR in a loop and report only new, actionable changes.
+
+## Inputs
+
+- `repo` (e.g. `eupholio/eupholio`)
+- `pr` number
+- optional baseline timestamp / known comment ids
+
+## Workflow
+
+1. Check CI state.
+   - `gh pr checks <pr> --repo <repo>`
+2. Pull review comments.
+   - `gh api repos/<repo>/pulls/<pr>/comments`
+3. Pull unresolved review threads.
+   - GraphQL `reviewThreads` query; filter `isResolved=false`.
+4. Compare against previous snapshot (ids/timestamps).
+5. Output only deltas:
+   - newly failed checks
+   - newly added comments
+   - unresolved thread count changes
+
+## Triage Rules
+
+- If all checks pass and no new comments: report `NO_CHANGE`.
+- If comments are only style/typo/doc nits: classify as `safe-fix candidates`.
+- If comments touch calculation semantics/API contracts: classify as `human decision required`.
+
+## Suggested Output Format
+
+- CI: pass/fail summary
+- New comments: count + links
+- Unresolved threads: count
+- Next action: `none` / `run pr-autofix-safe` / `ask human`


### PR DESCRIPTION
## Summary
- add `skills/pr-watchdog/SKILL.md` for CI/comment delta monitoring
- add `skills/pr-autofix-safe/SKILL.md` for safe auto-fix + resolve workflow
- update `AGENTS.md` branch workflow guidance to `main`-based flow

## Notes
- skills are operational playbooks for repeatable PR review loops
- semantic/logic changes remain explicitly blocked in autofix skill