### PR TITLE
fix(core): keep per-year carry_out_cost consistent with rounded qty/avg

### DIFF
--- a/eupholio-core/README.md
+++ b/eupholio-core/README.md
@@ -11,6 +11,7 @@ Implemented:
 - External rounding override input (`rounding`)
 - Go vs Rust parity scripts
 - Year mismatch handling: events whose `event.ts` year differs from `tax_year` are emitted as warnings (`YearMismatch` / `EVENT_YEAR_MISMATCH`) and excluded from calculation
+- Per-year rounding consistency for total-average: `carry_out_cost` is derived from rounded `carry_out_qty × average_cost_per_unit` (then rounded by JPY rule)
 
 Not yet fully implemented:
 - Exchange-specific normalizers

--- a/eupholio-core/src/engine/total_average.rs
+++ b/eupholio-core/src/engine/total_average.rs
@@ -284,7 +284,10 @@ fn apply_per_year_rounding_to_asset_summary(summary: &mut YearlyAssetSummary, po
     summary.average_cost_per_unit = round_by_rule(summary.average_cost_per_unit, policy.unit_price);
     summary.realized_pnl_jpy = round_by_rule(summary.realized_pnl_jpy, jpy_rule);
     summary.carry_out_qty = round_by_rule(summary.carry_out_qty, policy.quantity);
-    summary.carry_out_cost = round_by_rule(summary.carry_out_cost, jpy_rule);
+    summary.carry_out_cost = round_by_rule(
+        summary.carry_out_qty * summary.average_cost_per_unit,
+        jpy_rule,
+    );
 }
 
 fn round_by_rule(v: Decimal, rule: RoundRule) -> Decimal {

--- a/eupholio-core/src/lib.rs
+++ b/eupholio-core/src/lib.rs
@@ -97,7 +97,7 @@ fn apply_rounding(report: &mut Report, policy: &RoundingPolicy) {
             y.average_cost_per_unit = round_by_rule(y.average_cost_per_unit, policy.unit_price);
             y.realized_pnl_jpy = round_by_rule(y.realized_pnl_jpy, jpy_rule);
             y.carry_out_qty = round_by_rule(y.carry_out_qty, policy.quantity);
-            y.carry_out_cost = round_by_rule(y.carry_out_cost, jpy_rule);
+            y.carry_out_cost = round_by_rule(y.carry_out_qty * y.average_cost_per_unit, jpy_rule);
         }
     }
 }

--- a/eupholio-core/tests/per_year_carry_consistency.rs
+++ b/eupholio-core/tests/per_year_carry_consistency.rs
@@ -1,0 +1,72 @@
+use chrono::{TimeZone, Utc};
+use eupholio_core::{
+    calculate,
+    config::{Config, CostMethod, RoundRule, RoundingMode, RoundingPolicy, RoundingTiming},
+    event::Event,
+};
+use rust_decimal_macros::dec;
+use std::collections::HashMap;
+
+fn ts(y: i32, m: u32, d: u32) -> chrono::DateTime<Utc> {
+    Utc.with_ymd_and_hms(y, m, d, 0, 0, 0).unwrap()
+}
+
+#[test]
+fn per_year_rounding_keeps_carry_out_cost_coherent_with_qty_and_avg() {
+    let events = vec![
+        Event::Acquire {
+            id: "a1".into(),
+            asset: "BTC".into(),
+            qty: dec!(2.4),
+            jpy_cost: dec!(241.44),
+            ts: ts(2026, 1, 1),
+        },
+        Event::Dispose {
+            id: "d1".into(),
+            asset: "BTC".into(),
+            qty: dec!(1.0),
+            jpy_proceeds: dec!(150),
+            ts: ts(2026, 1, 2),
+        },
+    ];
+
+    let mut currency = HashMap::new();
+    currency.insert(
+        "JPY".to_string(),
+        RoundRule {
+            scale: 0,
+            mode: RoundingMode::HalfUp,
+        },
+    );
+
+    let report = calculate(
+        Config {
+            method: CostMethod::TotalAverage,
+            tax_year: 2026,
+            rounding: RoundingPolicy {
+                currency,
+                unit_price: RoundRule {
+                    scale: 0,
+                    mode: RoundingMode::HalfUp,
+                },
+                quantity: RoundRule {
+                    scale: 0,
+                    mode: RoundingMode::HalfUp,
+                },
+                timing: RoundingTiming::PerYear,
+            },
+        },
+        &events,
+    );
+
+    let summary = &report
+        .yearly_summary
+        .as_ref()
+        .unwrap()
+        .by_asset["BTC"];
+
+    assert_eq!(summary.average_cost_per_unit, dec!(101));
+    assert_eq!(summary.carry_out_qty, dec!(1));
+    assert_eq!(summary.carry_out_cost, dec!(101));
+    assert_eq!(summary.carry_out_cost, summary.carry_out_qty * summary.average_cost_per_unit);
+}


### PR DESCRIPTION
## Summary
- ensure per-year `carry_out_cost` is derived from rounded `carry_out_qty` and rounded `average_cost_per_unit`
- apply JPY rounding after recomputation to keep yearly summary fields coherent
- add regression test for carry consistency invariant
- update README note for implemented per-year consistency behavior

## Verification
- `cargo test` passed (including new `per_year_carry_consistency` test)

## Why
This prevents subtle inconsistency in per-year summaries where independently rounded derived fields could drift from each other.