### PR TITLE
docs(core): lock per_year semantics and add rounding-order regression

### DIFF
--- a/eupholio-core/doc/13-per-year-semantics.md
+++ b/eupholio-core/doc/13-per-year-semantics.md
@@ -17,7 +17,7 @@ This note locks current `per_year` behavior in `eupholio-core` to avoid interpre
    - `carry_out_cost` is computed from the rounded fields and then rounded by JPY rule:
      - `carry_out_cost = round_jpy(rounded_carry_out_qty * rounded_average_cost_per_unit)`
 4. Invariant target in yearly summary:
-   - `carry_out_cost` must remain coherent with rounded `carry_out_qty` and `average_cost_per_unit`.
+   - `carry_out_cost == round_jpy(carry_out_qty * average_cost_per_unit)` (using `rounding.currency["JPY"]`, defaulting to scale=0 HalfUp).
 
 ## Related paths
 

--- a/eupholio-core/doc/13-per-year-semantics.md
+++ b/eupholio-core/doc/13-per-year-semantics.md
@@ -1,0 +1,26 @@
+# 13. Per-year semantics lock
+
+This note locks current `per_year` behavior in `eupholio-core` to avoid interpretation drift.
+
+## Scope
+
+- Applies to `method=total_average` with `rounding.timing=per_year`.
+- `method=moving_average` + `timing=per_year` is unsupported and rejected by validation.
+
+## Locked behavior
+
+1. Event processing is performed without per-event rounding.
+2. Rounding is applied when finalizing yearly summary values.
+3. For each asset summary:
+   - `average_cost_per_unit` is rounded by `rounding.unit_price`.
+   - `carry_out_qty` is rounded by `rounding.quantity`.
+   - `carry_out_cost` is computed from the rounded fields and then rounded by JPY rule:
+     - `carry_out_cost = round_jpy(rounded_carry_out_qty * rounded_average_cost_per_unit)`
+4. Invariant target in yearly summary:
+   - `carry_out_cost` must remain coherent with rounded `carry_out_qty` and `average_cost_per_unit`.
+
+## Related paths
+
+- `src/engine/total_average.rs`
+- `src/lib.rs` (`report_only` rounding coherence path)
+- `tests/per_year_carry_consistency.rs`

--- a/eupholio-core/doc/13-per-year-semantics.md
+++ b/eupholio-core/doc/13-per-year-semantics.md
@@ -5,7 +5,7 @@ This note locks current `per_year` behavior in `eupholio-core` to avoid interpre
 ## Scope
 
 - Applies to `method=total_average` with `rounding.timing=per_year`.
-- `method=moving_average` + `timing=per_year` is unsupported and rejected by validation.
+- `method=moving_average` + `timing=per_year` is not supported by CLI/input validation (rejected there); in the core library `calculate` path it is accepted but treated as `rounding.timing=report_only`.
 
 ## Locked behavior
 

--- a/eupholio-core/doc/README.md
+++ b/eupholio-core/doc/README.md
@@ -28,3 +28,5 @@ This directory contains design and operational documentation for `eupholio-core`
   - Collected summary for PR readiness checkpoints
 - [12-dev-workflows.md](./12-dev-workflows.md)
   - Reusable development and review loops
+- [13-per-year-semantics.md](./13-per-year-semantics.md)
+  - Locked semantics for per-year rounding behavior

--- a/eupholio-core/tests/per_year_carry_consistency.rs
+++ b/eupholio-core/tests/per_year_carry_consistency.rs
@@ -70,3 +70,53 @@ fn per_year_rounding_keeps_carry_out_cost_coherent_with_qty_and_avg() {
     assert_eq!(summary.carry_out_cost, dec!(101));
     assert_eq!(summary.carry_out_cost, summary.carry_out_qty * summary.average_cost_per_unit);
 }
+
+#[test]
+fn per_year_rounding_applies_jpy_rounding_after_rounded_qty_avg_product() {
+    let events = vec![Event::Acquire {
+        id: "a1".into(),
+        asset: "BTC".into(),
+        qty: dec!(1.04),
+        jpy_cost: dec!(104.52),
+        ts: ts(2026, 1, 1),
+    }];
+
+    let mut currency = HashMap::new();
+    currency.insert(
+        "JPY".to_string(),
+        RoundRule {
+            scale: 0,
+            mode: RoundingMode::HalfUp,
+        },
+    );
+
+    let report = calculate(
+        Config {
+            method: CostMethod::TotalAverage,
+            tax_year: 2026,
+            rounding: RoundingPolicy {
+                currency,
+                unit_price: RoundRule {
+                    scale: 1,
+                    mode: RoundingMode::HalfUp,
+                },
+                quantity: RoundRule {
+                    scale: 0,
+                    mode: RoundingMode::HalfUp,
+                },
+                timing: RoundingTiming::PerYear,
+            },
+        },
+        &events,
+    );
+
+    let summary = &report
+        .yearly_summary
+        .as_ref()
+        .unwrap()
+        .by_asset["BTC"];
+
+    assert_eq!(summary.carry_out_qty, dec!(1));
+    assert_eq!(summary.average_cost_per_unit, dec!(100.5));
+    assert_eq!(summary.carry_out_cost, dec!(101));
+}

--- a/eupholio-core/tests/per_year_carry_consistency.rs
+++ b/eupholio-core/tests/per_year_carry_consistency.rs
@@ -77,7 +77,7 @@ fn per_year_rounding_applies_jpy_rounding_after_rounded_qty_avg_product() {
         id: "a1".into(),
         asset: "BTC".into(),
         qty: dec!(1.04),
-        jpy_cost: dec!(104.52),
+        jpy_cost: dec!(104.47),
         ts: ts(2026, 1, 1),
     }];
 


### PR DESCRIPTION
## Summary
- add `doc/13-per-year-semantics.md` to lock current `per_year` semantics
- document carry-out coherence rule: `carry_out_cost` is derived from rounded qty/avg and then JPY-rounded
- add regression test for rounding order in `per_year_carry_consistency.rs`
- update docs index

## Verification
- cargo test -q

## Scope
- docs + tests only
- no accounting algorithm change in this PR