### PR TITLE
test(cli): fill key CLI coverage gaps

### DIFF
--- a/eupholio-core/tests/cli_e2e.rs
+++ b/eupholio-core/tests/cli_e2e.rs
@@ -230,7 +230,7 @@ fn cli_calc_default_subcommand_works() {
 }
 
 #[test]
-fn cli_validate_warn_and_error_for_carry_in_moving_average() {
+fn cli_validate_warn_for_carry_in_moving_average() {
     let input = r#"{
       "method":"moving_average",
       "tax_year":2026,


### PR DESCRIPTION
## Summary
- add CLI e2e tests for version subcommand
- add CLI e2e test for default subcommand behavior (no subcommand => calc)
- add CLI validate test covering moving_average carry_in warning paths
- add CLI calc negative test for invalid method path

## Verification
- cargo test -q (eupholio-core)

## Scope
- tests only; no runtime behavior changes