### PR TITLE
feat(normalizer): add coincheck phase-2 trade history mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,7 @@ dependencies = [
  "chrono",
  "csv",
  "eupholio-core",
+ "regex",
  "rust_decimal",
  "serde_json",
 ]

--- a/eupholio-normalizer/Cargo.toml
+++ b/eupholio-normalizer/Cargo.toml
@@ -8,6 +8,7 @@ chrono = { version = "0.4", features = ["serde"] }
 rust_decimal = { version = "1", features = ["serde"] }
 eupholio-core = { path = "../eupholio-core" }
 csv = "1"
+regex = "1"
 
 [dev-dependencies]
 serde_json = "1"

--- a/eupholio-normalizer/doc/19-normalizer-coincheck-trade-history-mapping.md
+++ b/eupholio-normalizer/doc/19-normalizer-coincheck-trade-history-mapping.md
@@ -1,0 +1,52 @@
+# 19. Phase-2 normalizer mapping: Coincheck trade history CSV
+
+This document freezes the phase-2 mapping for Coincheck trade history CSV.
+
+- Source: `pkg/coincheck` extractor/translator path
+- Raw format: Coincheck trade history CSV
+- Scope: `Completed trading contracts` rows only (Acquire/Dispose)
+
+## Conversion target
+
+`eupholio-core::event::Event`
+
+## Row-level rules
+
+- `operation = Completed trading contracts` -> mapped to `Event::Acquire` or `Event::Dispose`
+- other `operation` values -> skipped with explicit diagnostic (`unsupported operation`)
+
+## Side detection
+
+A completed-trade row contains comment metadata like:
+
+`Rate: 5000000.0, Pair: btc_jpy`
+
+where pair means `QUOTE_BASE`.
+
+- If `trading_currency == QUOTE` -> `Event::Acquire` of `QUOTE`
+- If `trading_currency == BASE` -> `Event::Dispose` of `QUOTE`
+- Otherwise -> hard error (`invalid trading currency`)
+
+This phase only supports `BASE = JPY`.
+
+## Field mapping table
+
+| Source column | Acquire mapping | Dispose mapping | Notes |
+| --- | --- | --- | --- |
+| `id` | `id = "{id}:acquire"` | `id = "{id}:dispose"` | Stable event ID |
+| `comment` (`Pair`) | `asset = QUOTE` | `asset = QUOTE` | Upper-cased |
+| `amount` | `qty = amount` | `qty = amount / rate` | Dispose amount is JPY received |
+| `comment` (`Rate`) | used in cost formula | used in qty formula | Decimal rate |
+| `fee` | used in cost formula | used in proceeds formula | blank fee = 0 |
+| `time` | `ts = time` | `ts = time` | Parsed `%Y-%m-%d %H:%M:%S %z` then converted to UTC |
+
+## JPY formulas
+
+- Acquire: `jpy_cost = (rate * amount) + fee`
+- Dispose: `jpy_proceeds = amount - fee`
+
+## Known limits (intentional in phase-2)
+
+- No `Received`, `Sent`, `Bank Withdrawal`, or cancel rows yet (diagnosed and skipped)
+- Requires parsable `Rate: ..., Pair: ...` comment shape
+- Supports only `*_jpy` pairs for now

--- a/eupholio-normalizer/doc/README.md
+++ b/eupholio-normalizer/doc/README.md
@@ -10,3 +10,5 @@ Documentation for source-specific normalization into `eupholio-core::event::Even
   - Candidate selection notes for the next live-source adapter
 - [18-go-rust-migration-plan.md](./18-go-rust-migration-plan.md)
   - Staged migration/rollback plan from Go path to Rust path
+- [19-normalizer-coincheck-trade-history-mapping.md](./19-normalizer-coincheck-trade-history-mapping.md)
+  - Concrete phase-2 mapping for Coincheck trade history CSV (Acquire/Dispose scope)

--- a/eupholio-normalizer/src/bittrex.rs
+++ b/eupholio-normalizer/src/bittrex.rs
@@ -175,12 +175,14 @@ fn split_exchange(s: &str) -> Result<(&str, &str), String> {
 
 fn sanitize_diagnostic_value(s: &str) -> String {
     let mut out = String::new();
+    let mut len = 0usize;
     for c in s.chars() {
         if c.is_control() {
             continue;
         }
         out.push(c);
-        if out.chars().count() >= MAX_DIAGNOSTIC_VALUE_LEN {
+        len += 1;
+        if len >= MAX_DIAGNOSTIC_VALUE_LEN {
             out.push('…');
             break;
         }

--- a/eupholio-normalizer/src/coincheck.rs
+++ b/eupholio-normalizer/src/coincheck.rs
@@ -77,7 +77,7 @@ fn map_row(index: &HashMap<String, usize>, row: &StringRecord) -> Result<RowOutc
     }
 
     let amount = parse_decimal(get(index, row, "amount")?)?;
-    let trading_currency = get(index, row, "trading_currency")?;
+    let trading_currency = get(index, row, "trading_currency")?.to_ascii_uppercase();
     let fee = parse_optional_decimal(get(index, row, "fee")?)?.unwrap_or(Decimal::ZERO);
     let ts = parse_datetime(get(index, row, "time")?)?;
 
@@ -87,6 +87,10 @@ fn map_row(index: &HashMap<String, usize>, row: &StringRecord) -> Result<RowOutc
             "unsupported payment asset '{}', only JPY is supported",
             base
         ));
+    }
+
+    if rate <= Decimal::ZERO {
+        return Err(format!("rate must be > 0, got {}", rate));
     }
 
     let event = if trading_currency == quote {

--- a/eupholio-normalizer/src/coincheck.rs
+++ b/eupholio-normalizer/src/coincheck.rs
@@ -89,7 +89,8 @@ fn map_row(index: &HashMap<String, usize>, row: &StringRecord) -> Result<RowOutc
         ));
     }
 
-    if rate <= Decimal::ZERO {
+    // parse_rate_pair currently accepts non-negative rates only.
+    if rate == Decimal::ZERO {
         return Err(format!("rate must be > 0, got {}", rate));
     }
 

--- a/eupholio-normalizer/src/coincheck.rs
+++ b/eupholio-normalizer/src/coincheck.rs
@@ -51,9 +51,10 @@ pub fn normalize_trade_history_csv(raw: &str) -> Result<NormalizeResult, String>
             continue;
         }
 
-        match map_row(&header_index, &record)? {
-            RowOutcome::Event(event) => events.push(event),
-            RowOutcome::Unsupported(reason) => diagnostics.push(NormalizeDiagnostic { row, reason }),
+        match map_row(&header_index, &record) {
+            Ok(RowOutcome::Event(event)) => events.push(event),
+            Ok(RowOutcome::Unsupported(reason)) => diagnostics.push(NormalizeDiagnostic { row, reason }),
+            Err(e) => return Err(format!("row {}: {}", row, e)),
         }
     }
 
@@ -159,7 +160,7 @@ fn parse_rate_pair(comment: &str) -> Result<(Decimal, String, String), String> {
 
     let caps = re
         .captures(comment)
-        .ok_or_else(|| format!("failed to parse comment: {}", comment))?;
+        .ok_or_else(|| format!("failed to parse comment: {}", sanitize_diagnostic_value(comment)))?;
     let rate = parse_decimal(&caps[1])?;
     let quote = caps[2].to_ascii_uppercase();
     let base = caps[3].to_ascii_uppercase();

--- a/eupholio-normalizer/src/coincheck.rs
+++ b/eupholio-normalizer/src/coincheck.rs
@@ -1,0 +1,182 @@
+use chrono::{DateTime, Utc};
+use csv::StringRecord;
+use eupholio_core::event::Event;
+use regex::Regex;
+use rust_decimal::Decimal;
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::OnceLock;
+
+const OP_COMPLETED_TRADING_CONTRACTS: &str = "Completed trading contracts";
+const TIME_LAYOUT: &str = "%Y-%m-%d %H:%M:%S %z";
+const MAX_DIAGNOSTIC_VALUE_LEN: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NormalizeDiagnostic {
+    pub row: usize,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NormalizeResult {
+    pub events: Vec<Event>,
+    pub diagnostics: Vec<NormalizeDiagnostic>,
+}
+
+enum RowOutcome {
+    Event(Event),
+    Unsupported(String),
+}
+
+pub fn normalize_trade_history_csv(raw: &str) -> Result<NormalizeResult, String> {
+    let mut rdr = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .trim(csv::Trim::All)
+        .from_reader(raw.as_bytes());
+
+    let headers = rdr
+        .headers()
+        .map_err(|e| format!("invalid csv header: {}", e))?
+        .clone();
+    let header_index = build_header_index(&headers);
+
+    let mut events = Vec::new();
+    let mut diagnostics = Vec::new();
+
+    for (i, result) in rdr.records().enumerate() {
+        let row = i + 2;
+        let record = result.map_err(|e| format!("row {}: invalid csv row: {}", row, e))?;
+
+        if record.iter().all(|v| v.trim().is_empty()) {
+            continue;
+        }
+
+        match map_row(&header_index, &record)? {
+            RowOutcome::Event(event) => events.push(event),
+            RowOutcome::Unsupported(reason) => diagnostics.push(NormalizeDiagnostic { row, reason }),
+        }
+    }
+
+    Ok(NormalizeResult {
+        events,
+        diagnostics,
+    })
+}
+
+fn map_row(index: &HashMap<String, usize>, row: &StringRecord) -> Result<RowOutcome, String> {
+    let id = get(index, row, "id")?;
+    let operation = get(index, row, "operation")?;
+
+    if operation != OP_COMPLETED_TRADING_CONTRACTS {
+        return Ok(RowOutcome::Unsupported(format!(
+            "unsupported operation: operation='{}', id='{}'",
+            sanitize_diagnostic_value(operation),
+            sanitize_diagnostic_value(id)
+        )));
+    }
+
+    let amount = parse_decimal(get(index, row, "amount")?)?;
+    let trading_currency = get(index, row, "trading_currency")?;
+    let fee = parse_optional_decimal(get(index, row, "fee")?)?.unwrap_or(Decimal::ZERO);
+    let ts = parse_datetime(get(index, row, "time")?)?;
+
+    let (rate, quote, base) = parse_rate_pair(get(index, row, "comment")?)?;
+    if base != "JPY" {
+        return Err(format!(
+            "unsupported payment asset '{}', only JPY is supported",
+            base
+        ));
+    }
+
+    let event = if trading_currency == quote {
+        Event::Acquire {
+            id: format!("{}:acquire", id),
+            asset: quote.to_string(),
+            qty: amount,
+            jpy_cost: (rate * amount) + fee,
+            ts,
+        }
+    } else if trading_currency == base {
+        Event::Dispose {
+            id: format!("{}:dispose", id),
+            asset: quote.to_string(),
+            qty: amount / rate,
+            jpy_proceeds: amount - fee,
+            ts,
+        }
+    } else {
+        return Err(format!(
+            "invalid trading currency '{}' for pair {}_{}",
+            trading_currency, quote, base
+        ));
+    };
+
+    Ok(RowOutcome::Event(event))
+}
+
+fn build_header_index(headers: &StringRecord) -> HashMap<String, usize> {
+    headers
+        .iter()
+        .enumerate()
+        .map(|(i, col)| (col.to_string(), i))
+        .collect()
+}
+
+fn get<'a>(index: &HashMap<String, usize>, row: &'a StringRecord, key: &str) -> Result<&'a str, String> {
+    let i = *index
+        .get(key)
+        .ok_or_else(|| format!("missing required header {}", key))?;
+    row.get(i)
+        .map(str::trim)
+        .ok_or_else(|| format!("missing required field {}", key))
+}
+
+fn parse_decimal(s: &str) -> Result<Decimal, String> {
+    let v = s.replace(',', "");
+    Decimal::from_str(&v).map_err(|e| format!("invalid decimal '{}': {}", s, e))
+}
+
+fn parse_optional_decimal(s: &str) -> Result<Option<Decimal>, String> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    parse_decimal(trimmed).map(Some)
+}
+
+fn parse_datetime(s: &str) -> Result<DateTime<Utc>, String> {
+    let dt = DateTime::parse_from_str(s, TIME_LAYOUT)
+        .map_err(|e| format!("invalid datetime '{}': {}", s, e))?;
+    Ok(dt.with_timezone(&Utc))
+}
+
+fn parse_rate_pair(comment: &str) -> Result<(Decimal, String, String), String> {
+    static LIMIT_ORDER_RE: OnceLock<Regex> = OnceLock::new();
+    let re = LIMIT_ORDER_RE.get_or_init(|| {
+        Regex::new(r"Rate: ([0-9]+(?:\.[0-9]+)?), Pair: ([0-9a-z]+)_([0-9a-z]+)")
+            .expect("regex should compile")
+    });
+
+    let caps = re
+        .captures(comment)
+        .ok_or_else(|| format!("failed to parse comment: {}", comment))?;
+    let rate = parse_decimal(&caps[1])?;
+    let quote = caps[2].to_ascii_uppercase();
+    let base = caps[3].to_ascii_uppercase();
+    Ok((rate, quote, base))
+}
+
+fn sanitize_diagnostic_value(s: &str) -> String {
+    let mut out = String::new();
+    for c in s.chars() {
+        if c.is_control() {
+            continue;
+        }
+        out.push(c);
+        if out.chars().count() >= MAX_DIAGNOSTIC_VALUE_LEN {
+            out.push('…');
+            break;
+        }
+    }
+    out
+}

--- a/eupholio-normalizer/src/coincheck.rs
+++ b/eupholio-normalizer/src/coincheck.rs
@@ -152,8 +152,8 @@ fn parse_datetime(s: &str) -> Result<DateTime<Utc>, String> {
 }
 
 fn parse_rate_pair(comment: &str) -> Result<(Decimal, String, String), String> {
-    static LIMIT_ORDER_RE: OnceLock<Regex> = OnceLock::new();
-    let re = LIMIT_ORDER_RE.get_or_init(|| {
+    static COMMENT_RATE_PAIR_RE: OnceLock<Regex> = OnceLock::new();
+    let re = COMMENT_RATE_PAIR_RE.get_or_init(|| {
         Regex::new(r"Rate: ([0-9]+(?:\.[0-9]+)?), Pair: ([0-9a-z]+)_([0-9a-z]+)")
             .expect("regex should compile")
     });
@@ -169,12 +169,14 @@ fn parse_rate_pair(comment: &str) -> Result<(Decimal, String, String), String> {
 
 fn sanitize_diagnostic_value(s: &str) -> String {
     let mut out = String::new();
+    let mut len = 0usize;
     for c in s.chars() {
         if c.is_control() {
             continue;
         }
         out.push(c);
-        if out.chars().count() >= MAX_DIAGNOSTIC_VALUE_LEN {
+        len += 1;
+        if len >= MAX_DIAGNOSTIC_VALUE_LEN {
             out.push('…');
             break;
         }

--- a/eupholio-normalizer/src/lib.rs
+++ b/eupholio-normalizer/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod bittrex;
+pub mod coincheck;

--- a/eupholio-normalizer/tests/fixtures/normalizer/coincheck_history_smoke.csv
+++ b/eupholio-normalizer/tests/fixtures/normalizer/coincheck_history_smoke.csv
@@ -1,0 +1,5 @@
+id,time,operation,amount,trading_currency,price,original_currency,fee,comment
+cc-000,2026-01-01 00:00:00 +0900,Received,100000,JPY,,,0,""
+cc-101,2026-01-05 18:00:02 +0900,Completed trading contracts,0.1,BTC,,,500,"Rate: 5000000.0, Pair: btc_jpy"
+cc-102,2026-02-10 12:00:04 +0900,Completed trading contracts,700000,JPY,,,700,"Rate: 7000000.0, Pair: btc_jpy"
+cc-999,2026-02-20 12:00:00 +0900,Sent,-0.01,BTC,,,0,"Address: 1ABC"

--- a/eupholio-normalizer/tests/fixtures/normalizer/coincheck_history_smoke.normalized.json
+++ b/eupholio-normalizer/tests/fixtures/normalizer/coincheck_history_smoke.normalized.json
@@ -1,0 +1,18 @@
+[
+  {
+    "type": "Acquire",
+    "id": "cc-101:acquire",
+    "asset": "BTC",
+    "qty": "0.1",
+    "jpy_cost": "500500.0",
+    "ts": "2026-01-05T09:00:02Z"
+  },
+  {
+    "type": "Dispose",
+    "id": "cc-102:dispose",
+    "asset": "BTC",
+    "qty": "0.1",
+    "jpy_proceeds": "699300",
+    "ts": "2026-02-10T03:00:04Z"
+  }
+]

--- a/eupholio-normalizer/tests/normalizer_coincheck_smoke.rs
+++ b/eupholio-normalizer/tests/normalizer_coincheck_smoke.rs
@@ -113,3 +113,27 @@ cc6,2025-12-31 23:30:00 -0900,Completed trading contracts,1000,JPY,,,0,\"Rate: 1
         _ => panic!("expected dispose event"),
     }
 }
+
+#[test]
+fn coincheck_trading_currency_is_case_insensitive() {
+    let raw = "id,time,operation,amount,trading_currency,price,original_currency,fee,comment\n\
+cc7,2026-01-01 00:00:00 +0900,Completed trading contracts,1,btc,,,0,\"Rate: 10000.0, Pair: btc_jpy\"\n";
+
+    let normalized = normalize_trade_history_csv(raw).expect("normalization should succeed");
+    assert!(normalized.diagnostics.is_empty());
+    assert_eq!(normalized.events.len(), 1);
+    match &normalized.events[0] {
+        Event::Acquire { .. } => {}
+        _ => panic!("expected acquire event"),
+    }
+}
+
+#[test]
+fn coincheck_zero_rate_is_rejected() {
+    let raw = "id,time,operation,amount,trading_currency,price,original_currency,fee,comment\n\
+cc8,2026-01-01 00:00:00 +0900,Completed trading contracts,1000,JPY,,,0,\"Rate: 0, Pair: btc_jpy\"\n";
+
+    assert!(normalize_trade_history_csv(raw)
+        .expect_err("zero rate should fail")
+        .contains("rate must be > 0"));
+}


### PR DESCRIPTION
## Summary
- add coincheck phase-2 normalizer (Acquire / Dispose) in eupholio-normalizer
- add explicit diagnostics for unsupported rows and strict errors for malformed in-scope rows
- add mapping doc for Coincheck trade history conversion rules
- add fixtures + smoke/error-path tests and core flow assertion

## Verification
- cargo test -p eupholio-normalizer

## Scope
- normalizer + docs + tests only
- no core accounting algorithm changes