### PR TITLE
ci(rust): enforce minimum line coverage threshold

### DIFF
--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -57,6 +57,20 @@ jobs:
       - name: Generate coverage (workspace)
         run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
 
+      - name: Check coverage threshold (line >= 75%)
+        run: |
+          set -euo pipefail
+          read -r LH LF < <(awk -F: '$1=="LH"{lh+=$2} $1=="LF"{lf+=$2} END{print lh, lf}' lcov.info)
+          if [ "${LF}" -eq 0 ]; then
+            echo "No LF entries found in lcov.info"
+            exit 1
+          fi
+          COVERAGE=$(awk -v lh="$LH" -v lf="$LF" 'BEGIN { printf "%.2f", (lh/lf)*100 }')
+          echo "line coverage: ${COVERAGE}% (${LH}/${LF})"
+          echo "### Rust coverage" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Line coverage: **${COVERAGE}%** (${LH}/${LF})" >> "$GITHUB_STEP_SUMMARY"
+          awk -v cov="$COVERAGE" 'BEGIN { exit (cov+0 >= 75.0 ? 0 : 1) }'
+
       - name: Upload lcov artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -69,7 +69,10 @@ jobs:
           echo "line coverage: ${COVERAGE}% (${LH}/${LF})"
           echo "### Rust coverage" >> "$GITHUB_STEP_SUMMARY"
           echo "- Line coverage: **${COVERAGE}%** (${LH}/${LF})" >> "$GITHUB_STEP_SUMMARY"
-          awk -v cov="$COVERAGE" 'BEGIN { exit (cov+0 >= 75.0 ? 0 : 1) }'
+          if ! awk -v cov="$COVERAGE" 'BEGIN { exit (cov+0 >= 75.0 ? 0 : 1) }'; then
+            echo "Coverage ${COVERAGE}% is below the required threshold of 75%."
+            exit 1
+          fi
 
       - name: Upload lcov artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- add minimum line coverage gate to rust-coverage job
- parse lcov.info and fail CI when line coverage is below 75%
- write coverage summary to GitHub step summary for visibility

## Scope
- CI/workflow only
- no runtime logic changes