### PR TITLE
docs(normalizer): define coincheck phase-3 scope for Received/Sent

### DIFF
--- a/eupholio-normalizer/doc/20-normalizer-coincheck-phase3-scope.md
+++ b/eupholio-normalizer/doc/20-normalizer-coincheck-phase3-scope.md
@@ -8,16 +8,17 @@ Add support for transfer-like rows in Coincheck history with explicit mapping an
 
 ## Target operations (phase-3)
 
-- `Received` -> map to `Event::Transfer { direction: In }`
-- `Sent` -> map to `Event::Transfer { direction: Out }`
+- `Received` -> map to `Event::Transfer { direction: TransferDirection::In }`
+- `Sent` -> map to `Event::Transfer { direction: TransferDirection::Out }`
 
 Other operations remain out-of-scope and must continue to emit explicit diagnostics.
 
 ## Mapping draft
 
-Required columns (same as phase-2 baseline):
+Required headers (same as phase-2 baseline):
 
-- `id`, `time`, `operation`, `amount`, `trading_currency`
+- `id`, `time`, `operation`, `amount`, `trading_currency`, `fee`, `comment`
+  - `fee` / `comment` remain required for compatibility with phase-2 parser, but are not used in phase-3 transfer mapping.
 
 Mapping:
 

--- a/eupholio-normalizer/doc/20-normalizer-coincheck-phase3-scope.md
+++ b/eupholio-normalizer/doc/20-normalizer-coincheck-phase3-scope.md
@@ -1,0 +1,65 @@
+# 20. Coincheck normalizer phase-3 scope
+
+This document defines the next minimal extension after phase-2 (`Completed trading contracts`).
+
+## Goal
+
+Add support for transfer-like rows in Coincheck history with explicit mapping and diagnostics.
+
+## Target operations (phase-3)
+
+- `Received` -> map to `Event::Transfer { direction: In }`
+- `Sent` -> map to `Event::Transfer { direction: Out }`
+
+Other operations remain out-of-scope and must continue to emit explicit diagnostics.
+
+## Mapping draft
+
+Required columns (same as phase-2 baseline):
+
+- `id`, `time`, `operation`, `amount`, `trading_currency`
+
+Mapping:
+
+- `id` -> `id = "{id}:transfer_in" | "{id}:transfer_out"`
+- `trading_currency` -> `asset` (upper-cased)
+- `amount` -> `qty` (must be `> 0`)
+- `time` -> `ts` (existing parser, UTC-normalized)
+- `operation` -> transfer direction
+
+## Validation and diagnostics
+
+Hard errors:
+
+- invalid/missing required headers
+- invalid datetime
+- invalid decimal amount
+- non-positive transfer qty
+
+Warnings/diagnostics:
+
+- unsupported operation rows should still be collected as diagnostics (non-silent)
+
+## Test plan
+
+1. fixture: `coincheck_history_phase3_smoke.csv`
+2. fixture: expected normalized events JSON
+3. e2e smoke:
+   - includes `Received` + `Sent` rows
+   - flows into `eupholio_core::calculate`
+4. error-path tests:
+   - zero/negative amount
+   - invalid datetime
+   - unsupported operation diagnostics unchanged
+
+## Non-goals
+
+- bank withdrawal fiat semantics
+- staking/lending-specific operation semantics
+- fee reinterpretation for transfer rows
+
+## Exit criteria
+
+- deterministic mapping documented and implemented
+- fixtures + tests added
+- no regression in phase-2 tests

--- a/eupholio-normalizer/doc/20-normalizer-coincheck-phase3-scope.md
+++ b/eupholio-normalizer/doc/20-normalizer-coincheck-phase3-scope.md
@@ -22,7 +22,9 @@ Required headers (same as phase-2 baseline):
 
 Mapping:
 
-- `id` -> `id = "{id}:transfer_in" | "{id}:transfer_out"`
+- `id` ->
+  - `id = "{id}:transfer_in"` for `Received`
+  - `id = "{id}:transfer_out"` for `Sent`
 - `trading_currency` -> `asset` (upper-cased)
 - `amount` -> `qty` (must be `> 0`)
 - `time` -> `ts` (existing parser, UTC-normalized)
@@ -43,7 +45,7 @@ Warnings/diagnostics:
 
 ## Test plan
 
-1. fixture: `coincheck_history_phase3_smoke.csv`
+1. fixture: `coincheck_history_transfers_smoke.csv`
 2. fixture: expected normalized events JSON
 3. e2e smoke:
    - includes `Received` + `Sent` rows

--- a/eupholio-normalizer/doc/README.md
+++ b/eupholio-normalizer/doc/README.md
@@ -12,3 +12,5 @@ Documentation for source-specific normalization into `eupholio-core::event::Even
   - Staged migration/rollback plan from Go path to Rust path
 - [19-normalizer-coincheck-trade-history-mapping.md](./19-normalizer-coincheck-trade-history-mapping.md)
   - Concrete phase-2 mapping for Coincheck trade history CSV (Acquire/Dispose scope)
+- [20-normalizer-coincheck-phase3-scope.md](./20-normalizer-coincheck-phase3-scope.md)
+  - Scoped plan for adding Received/Sent transfer mapping in coincheck

--- a/eupholio-normalizer/doc/README.md
+++ b/eupholio-normalizer/doc/README.md
@@ -13,4 +13,4 @@ Documentation for source-specific normalization into `eupholio-core::event::Even
 - [19-normalizer-coincheck-trade-history-mapping.md](./19-normalizer-coincheck-trade-history-mapping.md)
   - Concrete phase-2 mapping for Coincheck trade history CSV (Acquire/Dispose scope)
 - [20-normalizer-coincheck-phase3-scope.md](./20-normalizer-coincheck-phase3-scope.md)
-  - Scoped plan for adding Received/Sent transfer mapping in coincheck
+  - Scoped plan for adding Received/Sent transfer mapping in Coincheck


### PR DESCRIPTION
## Summary
- add phase-3 scope doc for coincheck normalizer
- define minimal target operations (Received/Sent -> Transfer In/Out)
- document mapping/validation/test plan and non-goals

## Why
- enables immediate implementation after #11 merge with clear boundaries

## Checklist
- [x] doc added
- [x] README index updated