### PR TITLE
docs(normalizer): define coincheck phase-4 fiat transfer scope

### DIFF
--- a/eupholio-normalizer/doc/21-normalizer-coincheck-phase4-scope.md
+++ b/eupholio-normalizer/doc/21-normalizer-coincheck-phase4-scope.md
@@ -1,0 +1,54 @@
+# 21. Coincheck normalizer phase-4 scope
+
+This phase extends Coincheck normalization beyond phase-3 transfer support.
+
+## Goal
+
+Add minimal, explicit handling for fiat transfer operations while keeping tax-event semantics deterministic.
+
+## Target operations (phase-4)
+
+- `Withdrawal` (JPY) -> `Event::Transfer { direction: TransferDirection::Out }`
+- `Deposit` (JPY) -> `Event::Transfer { direction: TransferDirection::In }`
+
+## Scope rules
+
+- Only JPY fiat transfer rows are in scope for this phase.
+- Non-JPY fiat/asset variants remain unsupported and must emit diagnostics.
+- Existing operations from phase-2/3 remain unchanged.
+
+## Mapping draft
+
+- `id` ->
+  - `id = "{id}:fiat_transfer_in"` for `Deposit`
+  - `id = "{id}:fiat_transfer_out"` for `Withdrawal`
+- `trading_currency` -> `asset` (must be `JPY` in this phase)
+- `amount` -> `qty` (must be `> 0`)
+- `time` -> `ts` (UTC-normalized)
+
+## Validation
+
+Hard errors:
+- invalid/missing required headers
+- invalid datetime
+- invalid decimal amount
+- non-positive qty for in-scope operations
+
+Diagnostics:
+- unsupported operation rows
+- out-of-scope currency for phase-4 fiat mapping
+
+## Test plan
+
+1. fixture: `coincheck_history_fiat_transfers_smoke.csv`
+2. fixture: expected normalized events JSON
+3. tests:
+   - Deposit/Withdrawal mapped as Transfer In/Out
+   - non-JPY Deposit/Withdrawal diagnosed
+   - existing phase-2/3 mappings unchanged
+
+## Exit criteria
+
+- deterministic mapping and validation documented
+- fixture + smoke coverage added
+- all existing coincheck tests remain green

--- a/eupholio-normalizer/doc/README.md
+++ b/eupholio-normalizer/doc/README.md
@@ -14,3 +14,5 @@ Documentation for source-specific normalization into `eupholio-core::event::Even
   - Concrete phase-2 mapping for Coincheck trade history CSV (Acquire/Dispose scope)
 - [20-normalizer-coincheck-phase3-scope.md](./20-normalizer-coincheck-phase3-scope.md)
   - Scoped plan for adding Received/Sent transfer mapping in Coincheck
+- [21-normalizer-coincheck-phase4-scope.md](./21-normalizer-coincheck-phase4-scope.md)
+  - Scoped plan for Deposit/Withdrawal (JPY) transfer mapping in Coincheck


### PR DESCRIPTION
## Summary
- add phase-4 scope doc for Coincheck normalizer
- define minimal Deposit/Withdrawal (JPY) transfer mapping targets
- define validation/diagnostics rules and fixture-based test plan
- update docs index

## Why
- keeps implementation scope crisp before code changes
- preserves phase-2/3 behavior while extending in small steps