### PR TITLE
refactor(normalizer): improve Coincheck unsupported diagnostics

### DIFF
--- a/eupholio-normalizer/src/coincheck.rs
+++ b/eupholio-normalizer/src/coincheck.rs
@@ -122,8 +122,9 @@ fn map_row(index: &HashMap<String, usize>, row: &StringRecord) -> Result<RowOutc
 
     if operation != OP_COMPLETED_TRADING_CONTRACTS {
         return Ok(RowOutcome::Unsupported(format!(
-            "unsupported operation: operation='{}', id='{}'",
+            "unsupported operation: operation='{}', trading_currency='{}', id='{}'",
             sanitize_diagnostic_value(operation),
+            sanitize_diagnostic_value(&trading_currency),
             sanitize_diagnostic_value(id)
         )));
     }

--- a/eupholio-normalizer/tests/normalizer_coincheck_smoke.rs
+++ b/eupholio-normalizer/tests/normalizer_coincheck_smoke.rs
@@ -148,6 +148,21 @@ cc10,2026-01-01 00:00:00 +0900,Canceled,1,BTC,,,0,\"\"\n";
     assert!(normalized.diagnostics[0]
         .reason
         .contains("unsupported operation"));
+    assert!(normalized.diagnostics[0]
+        .reason
+        .contains("trading_currency='BTC'"));
+}
+
+#[test]
+fn coincheck_unsupported_operation_reason_is_sanitized() {
+    let raw = "id,time,operation,amount,trading_currency,price,original_currency,fee,comment\n\
+cc17,2026-01-01 00:00:00 +0900,Canceled\twith-control,1,BTC,,,0,\"\"\n";
+
+    let normalized = normalize_trade_history_csv(raw).expect("normalization should succeed");
+    assert_eq!(normalized.events.len(), 0);
+    assert_eq!(normalized.diagnostics.len(), 1);
+    assert!(!normalized.diagnostics[0].reason.contains('\n'));
+    assert!(!normalized.diagnostics[0].reason.contains('\t'));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- include `trading_currency` in unsupported-operation diagnostics for Coincheck rows
- add regression assertions for richer diagnostic context
- add sanitization regression for control-character input in unsupported operation text

## Validation
- cargo test -p eupholio-normalizer