### PR TITLE
ci: skip Windows matrix on pull_request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,24 @@ jobs:
     strategy:
       matrix:
         go-version: [1.22.x, 1.23.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Test
+      run: go test ./...
+
+  test_windows_main:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    strategy:
+      matrix:
+        go-version: [1.22.x, 1.23.x]
+    runs-on: windows-latest
     steps:
     - name: Install Go
       uses: actions/setup-go@v5


### PR DESCRIPTION
## Summary
- remove `windows-latest` from the default PR test matrix
- add a dedicated `test_windows_main` job that runs only on pushes to `main`
- keep Linux/macOS coverage on pull requests for faster feedback

## Why
PR feedback is currently slowed by Windows runners for changes that are usually validated on Linux/macOS in day-to-day development. This keeps Windows coverage on main without blocking every PR.

## Impact
- PRs: ubuntu + macos test matrix
- main push: ubuntu + macos + windows coverage
