### PR TITLE
ci: always run rust-core checks (remove path filters)

### DIFF
--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -4,27 +4,7 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'eupholio-core/**'
-      - 'eupholio-normalizer/**'
-      - 'scripts/compare_go_rust.py'
-      - 'scripts/go_cost_compare.go'
-      - 'scripts/check_validation_codes.py'
-      - 'scripts/parity_fixture_*.json'
-      - '.github/workflows/rust-core.yml'
   pull_request:
-    paths:
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'eupholio-core/**'
-      - 'eupholio-normalizer/**'
-      - 'scripts/compare_go_rust.py'
-      - 'scripts/go_cost_compare.go'
-      - 'scripts/check_validation_codes.py'
-      - 'scripts/parity_fixture_*.json'
-      - '.github/workflows/rust-core.yml'
 
 jobs:
   test-rust-core:


### PR DESCRIPTION
## Summary
- remove path filters from `.github/workflows/rust-core.yml`
- run `test-rust-core` and `parity-go-rust` on every pull request

## Why
Required checks can remain in `Expected` forever when path filters prevent job creation. Running this workflow on every PR keeps branch protection behavior deterministic and avoids merge deadlocks.
