### PR TITLE
feat(normalizer): add poloniex adapter support

### DIFF
--- a/eupholio-normalizer/doc/18-go-rust-migration-plan.md
+++ b/eupholio-normalizer/doc/18-go-rust-migration-plan.md
@@ -18,7 +18,7 @@ This plan defines a safe, staged replacement of legacy Go paths with Rust-based 
 
 ### Stage 1: Parallel adapter expansion
 
-- Add next live-source adapter (target: coincheck)
+- Add next live-source adapter (coincheck done, poloniex skeleton added)
 - For each adapter:
   - mapping doc
   - fixture pair (raw + normalized)

--- a/eupholio-normalizer/doc/23-bitflyer-api-poc-spec.md
+++ b/eupholio-normalizer/doc/23-bitflyer-api-poc-spec.md
@@ -1,0 +1,141 @@
+# 23. bitFlyer API対応 PoC 仕様（phase-1）
+
+## 目的
+
+CSVエクスポート前提の運用に加えて、bitFlyer APIから直接データ取得し、既存ノーマライザーへ流せる土台を作る。
+
+本PoCは「まず動く最小構成」を重視し、対象は**約定履歴（現物）**に限定する。
+
+---
+
+## スコープ（phase-1）
+
+### 対象
+- 取引所: bitFlyer
+- データ種別: 約定履歴（Trade / Execution）
+- マーケット: Spot（例: `BTC_JPY`）
+
+### 非対象（phase-2以降）
+- 入出金履歴
+- CFD/先物系
+- 建玉・ポジション情報
+- 複数取引所の同時統合
+
+---
+
+## 参照API（候補）
+
+> エンドポイント基底: `https://api.bitflyer.com/v1/`
+
+Private API（要認証）から約定系を取得する。
+実際の使用APIは実装時に最終確認するが、PoCでは以下方針:
+
+- 約定履歴取得（product_code / count / before / after でページング）
+- 必要に応じて注文情報APIを補助的に参照
+
+※ Public API（ticker/board）は本PoCでは使用しない。
+
+---
+
+## 認証仕様（必須）
+
+bitFlyer Private API認証ヘッダ:
+
+- `ACCESS-KEY`
+- `ACCESS-TIMESTAMP` (Unix timestamp)
+- `ACCESS-SIGN`
+
+署名:
+- `ACCESS-SIGN = HMAC-SHA256(secret, timestamp + method + path + body)`
+
+要件:
+- API key/secret は環境変数から読む
+- ログに secret を絶対に出さない
+- 署名失敗・401系は明確にエラー分類する
+
+---
+
+## データ変換方針
+
+APIレスポンスを**中間フォーマット**へ正規化し、既存 `bitflyer.rs` のCSV行相当へマップする。
+
+### 中間フォーマット（PoC）
+- `executed_at`
+- `side` (BUY/SELL)
+- `base_asset`
+- `base_qty`
+- `quote_asset` (JPY想定)
+- `quote_qty`
+- `fee_jpy`（取得可能なら）
+- `order_id`（または execution_id から合成ID）
+
+### 既存ロジック接続
+最終的には既存の `Event::Acquire / Event::Dispose` マッピングに接続する。
+
+---
+
+## ページング・取得戦略
+
+- `count` は固定上限（例: 100）
+- `before/after` で過去分を辿る
+- 無限ループ防止で最大ページ数を設定
+- APIレート制限を考慮し、短いsleepまたはリトライ間隔を入れる
+
+---
+
+## エラー設計（PoC）
+
+### Hard error
+- 認証失敗
+- APIレスポンス形式不正
+- 必須フィールド欠損
+- JPY建て以外（phase-1では非対応として失敗）
+
+### Diagnostic（継続可能）
+- side不正
+- 未対応フィールド構成
+- 1行単位での変換不能
+
+---
+
+## CLI想定（PoC）
+
+実行イメージ:
+
+```bash
+cargo run -p eupholio-normalizer -- \
+  --source bitflyer-api \
+  --product-code BTC_JPY \
+  --since 2025-01-01T00:00:00Z \
+  --until 2025-12-31T23:59:59Z
+```
+
+環境変数:
+- `BITFLYER_API_KEY`
+- `BITFLYER_API_SECRET`
+
+---
+
+## セキュリティ・運用ルール
+
+- 秘密情報は環境変数のみ（ファイル平文保存禁止）
+- ログに署名素材（timestamp+path+body）を出しすぎない
+- リトライは指数バックオフ（最大回数制限あり）
+
+---
+
+## 受け入れ条件（phase-1 Done）
+
+- 指定期間の約定履歴をAPIから取得できる
+- 既存bitFlyer正規化イベント（Acquire/Dispose）に変換できる
+- 最低1つの固定fixtureで再現テストが通る
+- 認証失敗/レート制限/フォーマット異常の主要エラーパスがテストされる
+
+---
+
+## 次フェーズ候補
+
+1. 入出金API対応
+2. JPY以外のクオート資産対応
+3. Coincheck APIアダプタへ横展開
+4. API取得結果のスナップショットテスト自動化

--- a/eupholio-normalizer/doc/24-api-crate-split-architecture.md
+++ b/eupholio-normalizer/doc/24-api-crate-split-architecture.md
@@ -1,0 +1,67 @@
+# 24. APIクレート分離アーキテクチャ案
+
+## 方針
+
+`eupholio-normalizer` は純粋変換ロジックに集中し、
+取引所APIアクセス（認証/署名/リトライ/レート制限）は別クレートへ分離する。
+
+---
+
+## 想定クレート構成
+
+- `eupholio-normalizer`
+  - 入力DTO → 正規化イベント
+  - API依存なし
+
+- `eupholio-exchange-api`（新規）
+  - 取引所APIクライアント（phase-1は bitFlyer）
+  - 認証ヘッダ生成（HMAC-SHA256）
+  - ページング/リトライ/エラー分類
+
+- `eupholio-cli`（既存/将来）
+  - API取得 + normalizer実行を接続
+
+---
+
+## 責務境界
+
+### eupholio-exchange-api
+- `BitflyerClient`:
+  - `list_executions(...) -> Vec<ExecutionRecord>`
+- `Signer`:
+  - `sign(timestamp, method, path, body) -> hex`
+- `RateLimitPolicy`:
+  - 連打抑制
+- `ApiError`:
+  - Auth / RateLimited / Transport / Decode / Unexpected
+
+### eupholio-normalizer
+- `normalize_bitflyer_records(records)`
+- API都合の情報を受け取らない（中間DTO化して吸収）
+
+---
+
+## WASM前提の設計ルール
+
+- secretをWASMに置かない
+- 署名処理はサーバー側（BFF/Backend）責務
+- WASMは「取得済みデータの正規化」に専念
+
+---
+
+## phase-1実装ステップ
+
+1. `eupholio-exchange-api` 新規作成（bitFlyer executionsのみ）
+2. `ExecutionRecord` DTO定義
+3. `eupholio-normalizer` 側にDTO入力関数を追加
+4. CLIで end-to-end 実行可能にする
+5. fixture + モックでテスト整備
+
+---
+
+## Done条件
+
+- API層と正規化層がcrate境界で分離されている
+- normalizer単体テストがAPI無しで完結
+- APIクレートは秘密情報マスク/エラー分類を実装
+- 将来の取引所追加が `eupholio-exchange-api` 内拡張で対応可能

--- a/eupholio-normalizer/src/lib.rs
+++ b/eupholio-normalizer/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod bitflyer;
 pub mod bittrex;
 pub mod coincheck;
+pub mod poloniex;

--- a/eupholio-normalizer/src/poloniex.rs
+++ b/eupholio-normalizer/src/poloniex.rs
@@ -1,0 +1,372 @@
+use chrono::{DateTime, Utc};
+use csv::StringRecord;
+use eupholio_core::event::{Event, TransferDirection};
+use rust_decimal::Decimal;
+use std::collections::HashMap;
+use std::str::FromStr;
+
+const TRADE_HEADERS: &[&str] = &[
+    "Date",
+    "Market",
+    "Category",
+    "Type",
+    "Price",
+    "Amount",
+    "Total",
+    "Fee",
+    "Order Number",
+    "Base Total Less Fee",
+    "Quote Total Less Fee",
+    "Fee Currency",
+    "Fee Total",
+];
+
+const DEPOSIT_HEADERS: &[&str] = &["Date", "Currency", "Amount", "Address", "Status"];
+const WITHDRAWAL_HEADERS: &[&str] = &[
+    "Date",
+    "Currency",
+    "Amount",
+    "Fee Deducted",
+    "Amount - Fee",
+    "Address",
+    "Status",
+];
+const DISTRIBUTION_HEADERS: &[&str] = &["date", "currency", "amount", "wallet"];
+
+const TYPE_BUY: &str = "Buy";
+const TYPE_SELL: &str = "Sell";
+const MAX_DIAGNOSTIC_VALUE_LEN: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NormalizeDiagnostic {
+    pub row: usize,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NormalizeResult {
+    pub events: Vec<Event>,
+    pub diagnostics: Vec<NormalizeDiagnostic>,
+}
+
+pub fn normalize_trade_history_csv(raw: &str) -> Result<NormalizeResult, String> {
+    let mut rdr = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .trim(csv::Trim::All)
+        .from_reader(raw.as_bytes());
+
+    let headers = rdr
+        .headers()
+        .map_err(|e| format!("invalid csv header: {}", e))?
+        .clone();
+    validate_headers(&headers, TRADE_HEADERS)?;
+    let idx = build_header_index(&headers);
+
+    let mut events = Vec::new();
+    let mut diagnostics = Vec::new();
+
+    for (i, rec) in rdr.records().enumerate() {
+        let row = i + 2;
+        let rec = rec.map_err(|e| format!("row {}: invalid csv row: {}", row, e))?;
+        if rec.iter().all(|v| v.trim().is_empty()) {
+            continue;
+        }
+
+        let trade_type = get(&idx, &rec, "Type")?;
+        if trade_type != TYPE_BUY && trade_type != TYPE_SELL {
+            diagnostics.push(NormalizeDiagnostic {
+                row,
+                reason: format!(
+                    "unsupported trade type: type='{}', order_number='{}'",
+                    sanitize_diagnostic_value(trade_type),
+                    sanitize_diagnostic_value(get(&idx, &rec, "Order Number")?)
+                ),
+            });
+            continue;
+        }
+
+        let ts = parse_datetime(get(&idx, &rec, "Date")?, "%Y-%m-%d %H:%M:%S")?;
+        let market = get(&idx, &rec, "Market")?;
+        let (trading_asset, payment_asset) = parse_market(market)?;
+
+        let price = parse_decimal(get(&idx, &rec, "Price")?)?;
+        let amount = parse_decimal(get(&idx, &rec, "Amount")?)?;
+        let total = parse_decimal(get(&idx, &rec, "Total")?)?;
+        let base_total_less_fee = parse_decimal(get(&idx, &rec, "Base Total Less Fee")?)?.abs();
+        let quote_total_less_fee = parse_decimal(get(&idx, &rec, "Quote Total Less Fee")?)?.abs();
+
+        if payment_asset != "JPY" {
+            return Err(format!(
+                "row {}: unsupported payment asset '{}', only JPY is supported",
+                row, payment_asset
+            ));
+        }
+        if price <= Decimal::ZERO {
+            return Err(format!("row {}: price must be > 0, got {}", row, price));
+        }
+
+        let order_number = get(&idx, &rec, "Order Number")?;
+
+        let event = if trade_type == TYPE_BUY {
+            if quote_total_less_fee <= Decimal::ZERO {
+                return Err(format!(
+                    "row {}: buy qty must be > 0 after fee, got {}",
+                    row, quote_total_less_fee
+                ));
+            }
+            Event::Acquire {
+                id: format!("{}:acquire", order_number),
+                asset: trading_asset.to_string(),
+                qty: quote_total_less_fee,
+                jpy_cost: total,
+                ts,
+            }
+        } else {
+            if amount <= Decimal::ZERO {
+                return Err(format!("row {}: sell qty must be > 0, got {}", row, amount));
+            }
+            Event::Dispose {
+                id: format!("{}:dispose", order_number),
+                asset: trading_asset.to_string(),
+                qty: amount,
+                jpy_proceeds: base_total_less_fee,
+                ts,
+            }
+        };
+        events.push(event);
+    }
+
+    Ok(NormalizeResult {
+        events,
+        diagnostics,
+    })
+}
+
+pub fn normalize_deposit_history_csv(raw: &str) -> Result<NormalizeResult, String> {
+    let mut rdr = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .trim(csv::Trim::All)
+        .from_reader(raw.as_bytes());
+
+    let headers = rdr
+        .headers()
+        .map_err(|e| format!("invalid csv header: {}", e))?
+        .clone();
+    validate_headers(&headers, DEPOSIT_HEADERS)?;
+    let idx = build_header_index(&headers);
+
+    let mut events = Vec::new();
+    for (i, rec) in rdr.records().enumerate() {
+        let row = i + 2;
+        let rec = rec.map_err(|e| format!("row {}: invalid csv row: {}", row, e))?;
+        if rec.iter().all(|v| v.trim().is_empty()) {
+            continue;
+        }
+
+        let ts = parse_datetime(get(&idx, &rec, "Date")?, "%Y-%m-%d %H:%M:%S")?;
+        let asset = get(&idx, &rec, "Currency")?.to_ascii_uppercase();
+        let qty = parse_decimal(get(&idx, &rec, "Amount")?)?;
+        if qty <= Decimal::ZERO {
+            return Err(format!("row {}: deposit qty must be > 0, got {}", row, qty));
+        }
+
+        events.push(Event::Transfer {
+            id: format!("poloniex-deposit-{}", row),
+            asset,
+            qty,
+            direction: TransferDirection::In,
+            ts,
+        });
+    }
+
+    Ok(NormalizeResult {
+        events,
+        diagnostics: Vec::new(),
+    })
+}
+
+pub fn normalize_withdrawal_history_csv(raw: &str) -> Result<NormalizeResult, String> {
+    let mut rdr = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .trim(csv::Trim::All)
+        .from_reader(raw.as_bytes());
+
+    let headers = rdr
+        .headers()
+        .map_err(|e| format!("invalid csv header: {}", e))?
+        .clone();
+    validate_headers(&headers, WITHDRAWAL_HEADERS)?;
+    let idx = build_header_index(&headers);
+
+    let mut events = Vec::new();
+    for (i, rec) in rdr.records().enumerate() {
+        let row = i + 2;
+        let rec = rec.map_err(|e| format!("row {}: invalid csv row: {}", row, e))?;
+        if rec.iter().all(|v| v.trim().is_empty()) {
+            continue;
+        }
+
+        let ts = parse_datetime(get(&idx, &rec, "Date")?, "%Y-%m-%d %H:%M:%S")?;
+        let asset = get(&idx, &rec, "Currency")?.to_ascii_uppercase();
+
+        let amount = parse_decimal(get(&idx, &rec, "Amount")?)?;
+        if amount <= Decimal::ZERO {
+            return Err(format!(
+                "row {}: withdrawal qty must be > 0, got {}",
+                row, amount
+            ));
+        }
+
+        events.push(Event::Transfer {
+            id: format!("poloniex-withdrawal-{}", row),
+            asset: asset.clone(),
+            qty: amount,
+            direction: TransferDirection::Out,
+            ts,
+        });
+
+        let fee = parse_decimal(get(&idx, &rec, "Fee Deducted")?)?.abs();
+        if fee > Decimal::ZERO {
+            events.push(Event::Transfer {
+                id: format!("poloniex-withdrawal-fee-{}", row),
+                asset,
+                qty: fee,
+                direction: TransferDirection::Out,
+                ts,
+            });
+        }
+    }
+
+    Ok(NormalizeResult {
+        events,
+        diagnostics: Vec::new(),
+    })
+}
+
+pub fn normalize_distribution_history_csv(raw: &str) -> Result<NormalizeResult, String> {
+    let mut rdr = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .trim(csv::Trim::All)
+        .from_reader(raw.as_bytes());
+
+    let headers = rdr
+        .headers()
+        .map_err(|e| format!("invalid csv header: {}", e))?
+        .clone();
+    validate_headers(&headers, DISTRIBUTION_HEADERS)?;
+    let idx = build_header_index(&headers);
+
+    let mut events = Vec::new();
+    for (i, rec) in rdr.records().enumerate() {
+        let row = i + 2;
+        let rec = rec.map_err(|e| format!("row {}: invalid csv row: {}", row, e))?;
+        if rec.iter().all(|v| v.trim().is_empty()) {
+            continue;
+        }
+
+        let ts = parse_date(get(&idx, &rec, "date")?)?;
+        let asset = get(&idx, &rec, "currency")?.to_ascii_uppercase();
+        let qty = parse_decimal(get(&idx, &rec, "amount")?)?;
+        if qty <= Decimal::ZERO {
+            return Err(format!(
+                "row {}: distribution qty must be > 0, got {}",
+                row, qty
+            ));
+        }
+
+        events.push(Event::Income {
+            id: format!("poloniex-distribution-{}", row),
+            asset,
+            qty,
+            jpy_value: Decimal::ZERO,
+            ts,
+        });
+    }
+
+    Ok(NormalizeResult {
+        events,
+        diagnostics: Vec::new(),
+    })
+}
+
+fn validate_headers(headers: &StringRecord, required: &[&str]) -> Result<(), String> {
+    for h in required {
+        if !headers.iter().any(|x| x == *h) {
+            return Err(format!("missing required header {}", h));
+        }
+    }
+    Ok(())
+}
+
+fn build_header_index(headers: &StringRecord) -> HashMap<String, usize> {
+    headers
+        .iter()
+        .enumerate()
+        .map(|(i, col)| (col.to_string(), i))
+        .collect()
+}
+
+fn get<'a>(
+    idx: &HashMap<String, usize>,
+    row: &'a StringRecord,
+    key: &str,
+) -> Result<&'a str, String> {
+    let i = *idx
+        .get(key)
+        .ok_or_else(|| format!("missing required header {}", key))?;
+    row.get(i)
+        .map(str::trim)
+        .ok_or_else(|| format!("missing required field {}", key))
+}
+
+fn parse_decimal(s: &str) -> Result<Decimal, String> {
+    let v = s.replace(',', "");
+    Decimal::from_str(&v).map_err(|e| format!("invalid decimal '{}': {}", s, e))
+}
+
+fn parse_datetime(s: &str, layout: &str) -> Result<DateTime<Utc>, String> {
+    let dt = DateTime::parse_from_str(&format!("{} +0000", s), &format!("{} %z", layout))
+        .map_err(|e| format!("invalid datetime '{}': {}", s, e))?;
+    Ok(dt.with_timezone(&Utc))
+}
+
+fn parse_date(s: &str) -> Result<DateTime<Utc>, String> {
+    parse_datetime(&format!("{} 00:00:00", s), "%Y-%m-%d %H:%M:%S")
+}
+
+fn parse_market(s: &str) -> Result<(String, String), String> {
+    let mut parts = s.split('/');
+    let base = parts
+        .next()
+        .ok_or_else(|| format!("invalid market field {}", sanitize_diagnostic_value(s)))?;
+    let quote = parts
+        .next()
+        .ok_or_else(|| format!("invalid market field {}", sanitize_diagnostic_value(s)))?;
+    if parts.next().is_some() {
+        return Err(format!(
+            "invalid market field {}",
+            sanitize_diagnostic_value(s)
+        ));
+    }
+    Ok((
+        base.trim().to_ascii_uppercase(),
+        quote.trim().to_ascii_uppercase(),
+    ))
+}
+
+fn sanitize_diagnostic_value(s: &str) -> String {
+    let mut out = String::new();
+    let mut len = 0usize;
+    for c in s.chars() {
+        if c.is_control() {
+            continue;
+        }
+        out.push(c);
+        len += 1;
+        if len >= MAX_DIAGNOSTIC_VALUE_LEN {
+            out.push('…');
+            break;
+        }
+    }
+    out
+}

--- a/eupholio-normalizer/tests/fixtures/normalizer/poloniex_deposit_smoke.csv
+++ b/eupholio-normalizer/tests/fixtures/normalizer/poloniex_deposit_smoke.csv
@@ -1,0 +1,2 @@
+Date,Currency,Amount,Address,Status
+2026-01-03 08:00:00,BTC,0.02,addr1,COMPLETE

--- a/eupholio-normalizer/tests/fixtures/normalizer/poloniex_distribution_smoke.csv
+++ b/eupholio-normalizer/tests/fixtures/normalizer/poloniex_distribution_smoke.csv
@@ -1,0 +1,2 @@
+date,currency,amount,wallet
+2026-01-25,ETH,0.5,exchange

--- a/eupholio-normalizer/tests/fixtures/normalizer/poloniex_trade_smoke.csv
+++ b/eupholio-normalizer/tests/fixtures/normalizer/poloniex_trade_smoke.csv
@@ -1,0 +1,3 @@
+Date,Market,Category,Type,Price,Amount,Total,Fee,Order Number,Base Total Less Fee,Quote Total Less Fee,Fee Currency,Fee Total
+2026-01-05 10:00:00,BTC/JPY,Exchange,Buy,1000000,0.1,100000,0.001,1001,-100000,0.099,BTC,0.001
+2026-01-10 10:00:00,BTC/JPY,Exchange,Sell,1200000,0.05,60000,0.002,1002,59880,-0.05,JPY,120

--- a/eupholio-normalizer/tests/fixtures/normalizer/poloniex_trade_smoke.normalized.json
+++ b/eupholio-normalizer/tests/fixtures/normalizer/poloniex_trade_smoke.normalized.json
@@ -1,0 +1,50 @@
+[
+  {
+    "type": "Acquire",
+    "id": "1001:acquire",
+    "asset": "BTC",
+    "qty": "0.099",
+    "jpy_cost": "100000",
+    "ts": "2026-01-05T10:00:00Z"
+  },
+  {
+    "type": "Dispose",
+    "id": "1002:dispose",
+    "asset": "BTC",
+    "qty": "0.05",
+    "jpy_proceeds": "59880",
+    "ts": "2026-01-10T10:00:00Z"
+  },
+  {
+    "type": "Transfer",
+    "id": "poloniex-deposit-2",
+    "asset": "BTC",
+    "qty": "0.02",
+    "direction": "In",
+    "ts": "2026-01-03T08:00:00Z"
+  },
+  {
+    "type": "Transfer",
+    "id": "poloniex-withdrawal-2",
+    "asset": "BTC",
+    "qty": "0.01",
+    "direction": "Out",
+    "ts": "2026-01-20T09:00:00Z"
+  },
+  {
+    "type": "Transfer",
+    "id": "poloniex-withdrawal-fee-2",
+    "asset": "BTC",
+    "qty": "0.0001",
+    "direction": "Out",
+    "ts": "2026-01-20T09:00:00Z"
+  },
+  {
+    "type": "Income",
+    "id": "poloniex-distribution-2",
+    "asset": "ETH",
+    "qty": "0.5",
+    "jpy_value": "0",
+    "ts": "2026-01-25T00:00:00Z"
+  }
+]

--- a/eupholio-normalizer/tests/fixtures/normalizer/poloniex_withdrawal_smoke.csv
+++ b/eupholio-normalizer/tests/fixtures/normalizer/poloniex_withdrawal_smoke.csv
@@ -1,0 +1,2 @@
+Date,Currency,Amount,Fee Deducted,Amount - Fee,Address,Status
+2026-01-20 09:00:00,BTC,0.01,0.0001,0.0099,addr2,COMPLETE

--- a/eupholio-normalizer/tests/normalizer_poloniex_smoke.rs
+++ b/eupholio-normalizer/tests/normalizer_poloniex_smoke.rs
@@ -1,0 +1,99 @@
+use eupholio_core::config::{Config, CostMethod};
+use eupholio_core::event::{Event, TransferDirection};
+use eupholio_normalizer::poloniex::{
+    normalize_deposit_history_csv, normalize_distribution_history_csv, normalize_trade_history_csv,
+    normalize_withdrawal_history_csv,
+};
+
+#[test]
+fn poloniex_smoke_source_to_normalized_to_calculate() {
+    let trade_raw = include_str!("fixtures/normalizer/poloniex_trade_smoke.csv");
+    let deposit_raw = include_str!("fixtures/normalizer/poloniex_deposit_smoke.csv");
+    let withdrawal_raw = include_str!("fixtures/normalizer/poloniex_withdrawal_smoke.csv");
+    let distribution_raw = include_str!("fixtures/normalizer/poloniex_distribution_smoke.csv");
+    let expected_raw = include_str!("fixtures/normalizer/poloniex_trade_smoke.normalized.json");
+
+    let mut events = Vec::new();
+
+    let trade = normalize_trade_history_csv(trade_raw).expect("trade normalization should succeed");
+    let deposit =
+        normalize_deposit_history_csv(deposit_raw).expect("deposit normalization should succeed");
+    let withdrawal = normalize_withdrawal_history_csv(withdrawal_raw)
+        .expect("withdrawal normalization should succeed");
+    let distribution = normalize_distribution_history_csv(distribution_raw)
+        .expect("distribution normalization should succeed");
+
+    assert!(trade.diagnostics.is_empty());
+    assert!(deposit.diagnostics.is_empty());
+    assert!(withdrawal.diagnostics.is_empty());
+    assert!(distribution.diagnostics.is_empty());
+
+    events.extend(trade.events);
+    events.extend(deposit.events);
+    events.extend(withdrawal.events);
+    events.extend(distribution.events);
+
+    let expected: Vec<Event> =
+        serde_json::from_str(expected_raw).expect("fixture json should be valid");
+    assert_eq!(events, expected, "normalized output should match fixture");
+
+    let report = eupholio_core::calculate(
+        Config {
+            method: CostMethod::MovingAverage,
+            tax_year: 2026,
+            rounding: Default::default(),
+        },
+        &events,
+    );
+
+    assert_eq!(report.realized_pnl_jpy.to_string(), "9375");
+}
+
+#[test]
+fn poloniex_unsupported_trade_type_is_diagnosed() {
+    let raw = "Date,Market,Category,Type,Price,Amount,Total,Fee,Order Number,Base Total Less Fee,Quote Total Less Fee,Fee Currency,Fee Total\n\
+2026-01-05 10:00:00,BTC/JPY,Exchange,Margin,1000000,0.1,100000,0.001,1001,-100000,0.099,BTC,0.001\n";
+
+    let normalized = normalize_trade_history_csv(raw).expect("normalization should succeed");
+    assert_eq!(normalized.events.len(), 0);
+    assert_eq!(normalized.diagnostics.len(), 1);
+    assert!(normalized.diagnostics[0]
+        .reason
+        .contains("unsupported trade type"));
+}
+
+#[test]
+fn poloniex_non_jpy_payment_is_rejected() {
+    let raw = "Date,Market,Category,Type,Price,Amount,Total,Fee,Order Number,Base Total Less Fee,Quote Total Less Fee,Fee Currency,Fee Total\n\
+2026-01-05 10:00:00,BTC/USDT,Exchange,Buy,1000000,0.1,100000,0.001,1001,-100000,0.099,BTC,0.001\n";
+
+    assert!(normalize_trade_history_csv(raw)
+        .expect_err("non-JPY should fail")
+        .contains("only JPY is supported"));
+}
+
+#[test]
+fn poloniex_distribution_bad_date_is_rejected() {
+    let raw = "date,currency,amount,wallet\n2026/01/25,ETH,0.5,exchange\n";
+
+    assert!(normalize_distribution_history_csv(raw)
+        .expect_err("bad date should fail")
+        .contains("invalid datetime"));
+}
+
+#[test]
+fn poloniex_withdrawal_emits_fee_transfer_when_positive_fee() {
+    let raw = "Date,Currency,Amount,Fee Deducted,Amount - Fee,Address,Status\n\
+2026-01-20 09:00:00,BTC,0.01,0.0001,0.0099,addr2,COMPLETE\n";
+
+    let normalized = normalize_withdrawal_history_csv(raw).expect("normalization should succeed");
+    assert_eq!(normalized.events.len(), 2);
+
+    match &normalized.events[1] {
+        Event::Transfer { direction, qty, .. } => {
+            assert_eq!(*direction, TransferDirection::Out);
+            assert_eq!(qty.to_string(), "0.0001");
+        }
+        _ => panic!("expected transfer event"),
+    }
+}


### PR DESCRIPTION
## Summary
- add `eupholio-normalizer::poloniex` with CSV normalizers for trade/deposit/withdrawal/distribution
- add diagnostics-first handling for unsupported trade types
- add Poloniex smoke fixtures + tests (including calculate path)
- export new module in `lib.rs`
- update migration plan note for poloniex skeleton

## Notes
- trade mapping currently supports JPY quote only (non-JPY is rejected)
- withdrawal emits transfer-out for withdrawal amount and fee
- distribution maps to `Income` with `jpy_value=0` placeholder

## Validation
- `cargo test -p eupholio-normalizer`