### PR TITLE
ci: enforce full-repo format checks

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,44 @@
+name: format
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  rustfmt-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Check Rust formatting
+        run: cargo fmt --all -- --check
+
+  gofmt-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.x'
+      - name: Check Go formatting
+        shell: bash
+        run: |
+          set -euo pipefail
+          files=$(find . -type f -name '*.go' -not -path './vendor/*')
+          if [ -z "$files" ]; then
+            echo "No Go files found"
+            exit 0
+          fi
+
+          unformatted=$(gofmt -l $files)
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not gofmt-formatted:"
+            echo "$unformatted"
+            echo
+            echo "Run: gofmt -w <files>"
+            exit 1
+          fi

--- a/eupholio-core/src/bin/eupholio-core-cli.rs
+++ b/eupholio-core/src/bin/eupholio-core-cli.rs
@@ -1,4 +1,7 @@
-use std::{collections::{HashMap, HashSet}, io::{self, Read}};
+use std::{
+    collections::{HashMap, HashSet},
+    io::{self, Read},
+};
 
 use clap::{Parser, Subcommand};
 use eupholio_core::{
@@ -127,7 +130,11 @@ impl ValidationResult {
 }
 
 #[derive(Debug, Parser)]
-#[command(name = "eupholio-core-cli", version, about = "Eupholio core calculator CLI")]
+#[command(
+    name = "eupholio-core-cli",
+    version,
+    about = "Eupholio core calculator CLI"
+)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
@@ -163,8 +170,8 @@ fn is_moving_average_per_year(rounding: &RoundingPolicy, method: CostMethod) -> 
 }
 
 fn run(input: Input) -> Result<Report, io::Error> {
-    let method = parse_method(&input.method)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+    let method =
+        parse_method(&input.method).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
     let rounding = input.rounding.unwrap_or_default();
 
     if is_moving_average_per_year(&rounding, method) {
@@ -241,8 +248,7 @@ fn validate_input(input: &Input) -> ValidationResult {
     {
         out.push_error(
             ValidationCode::RoundingPerYearUnsupportedForMovingAverage,
-            "rounding.timing=per_year is not supported for method=moving_average"
-                .to_string(),
+            "rounding.timing=per_year is not supported for method=moving_average".to_string(),
         );
     }
 
@@ -295,13 +301,21 @@ fn validate_input(input: &Input) -> ValidationResult {
         if e.year() != input.tax_year {
             out.push_warning(
                 ValidationCode::EventYearMismatch,
-                format!("event year {} does not match tax_year {} (id={})", e.year(), input.tax_year, e.id()),
+                format!(
+                    "event year {} does not match tax_year {} (id={})",
+                    e.year(),
+                    input.tax_year,
+                    e.id()
+                ),
             );
         }
 
         let id = e.id().to_string();
         if !ids.insert(id.clone()) {
-            out.push_error(ValidationCode::DuplicateEventId, format!("duplicate event id: {id}"));
+            out.push_error(
+                ValidationCode::DuplicateEventId,
+                format!("duplicate event id: {id}"),
+            );
         }
 
         match e {
@@ -320,9 +334,7 @@ fn validate_input(input: &Input) -> ValidationResult {
                 }
             }
             Event::Dispose {
-                qty,
-                jpy_proceeds,
-                ..
+                qty, jpy_proceeds, ..
             } => {
                 if *qty <= Decimal::ZERO {
                     out.push_error(

--- a/eupholio-core/src/engine/moving_average.rs
+++ b/eupholio-core/src/engine/moving_average.rs
@@ -14,7 +14,11 @@ pub fn run_per_event(events: &[Event], tax_year: i32, policy: &RoundingPolicy) -
     run_inner(events, tax_year, Some(policy))
 }
 
-fn run_inner(events: &[Event], tax_year: i32, per_event_rounding: Option<&RoundingPolicy>) -> Report {
+fn run_inner(
+    events: &[Event],
+    tax_year: i32,
+    per_event_rounding: Option<&RoundingPolicy>,
+) -> Report {
     let mut positions: HashMap<String, Position> = HashMap::new();
     let mut realized = Decimal::ZERO;
     let mut income = Decimal::ZERO;
@@ -157,14 +161,10 @@ fn apply_per_event_rounding(
     round_realized: bool,
     round_income: bool,
 ) {
-    let jpy_rule = policy
-        .currency
-        .get("JPY")
-        .copied()
-        .unwrap_or(RoundRule {
-            scale: 0,
-            mode: RoundingMode::HalfUp,
-        });
+    let jpy_rule = policy.currency.get("JPY").copied().unwrap_or(RoundRule {
+        scale: 0,
+        mode: RoundingMode::HalfUp,
+    });
 
     if round_realized {
         *realized = round_by_rule(*realized, jpy_rule);

--- a/eupholio-core/src/engine/total_average.rs
+++ b/eupholio-core/src/engine/total_average.rs
@@ -41,7 +41,11 @@ pub fn run_per_year(events: &[Event], tax_year: i32, policy: &RoundingPolicy) ->
     run_with_carry_inner(events, tax_year, &HashMap::new(), None, Some(policy))
 }
 
-pub fn run_with_carry(events: &[Event], tax_year: i32, carry_in: &HashMap<String, CarryIn>) -> Report {
+pub fn run_with_carry(
+    events: &[Event],
+    tax_year: i32,
+    carry_in: &HashMap<String, CarryIn>,
+) -> Report {
     run_with_carry_inner(events, tax_year, carry_in, None, None)
 }
 
@@ -81,14 +85,10 @@ fn run_with_carry_inner(
         b.carry_in_cost = c.cost;
 
         if let Some(policy) = per_event_rounding {
-            let jpy_rule = policy
-                .currency
-                .get("JPY")
-                .copied()
-                .unwrap_or(RoundRule {
-                    scale: 0,
-                    mode: RoundingMode::HalfUp,
-                });
+            let jpy_rule = policy.currency.get("JPY").copied().unwrap_or(RoundRule {
+                scale: 0,
+                mode: RoundingMode::HalfUp,
+            });
             b.carry_in_qty = round_by_rule(b.carry_in_qty, policy.quantity);
             b.carry_in_cost = round_by_rule(b.carry_in_cost, jpy_rule);
         }
@@ -157,7 +157,13 @@ fn run_with_carry_inner(
         }
 
         if let Some(policy) = per_event_rounding {
-            apply_per_event_rounding(&mut buckets, &mut income, policy, touched_asset, round_income);
+            apply_per_event_rounding(
+                &mut buckets,
+                &mut income,
+                policy,
+                touched_asset,
+                round_income,
+            );
         }
     }
 
@@ -215,14 +221,10 @@ fn run_with_carry_inner(
     }
 
     if let Some(policy) = per_year_rounding {
-        let jpy_rule = policy
-            .currency
-            .get("JPY")
-            .copied()
-            .unwrap_or(RoundRule {
-                scale: 0,
-                mode: RoundingMode::HalfUp,
-            });
+        let jpy_rule = policy.currency.get("JPY").copied().unwrap_or(RoundRule {
+            scale: 0,
+            mode: RoundingMode::HalfUp,
+        });
         income = round_by_rule(income, jpy_rule);
     }
 
@@ -242,14 +244,10 @@ fn apply_per_event_rounding(
     touched_asset: Option<&str>,
     round_income: bool,
 ) {
-    let jpy_rule = policy
-        .currency
-        .get("JPY")
-        .copied()
-        .unwrap_or(RoundRule {
-            scale: 0,
-            mode: RoundingMode::HalfUp,
-        });
+    let jpy_rule = policy.currency.get("JPY").copied().unwrap_or(RoundRule {
+        scale: 0,
+        mode: RoundingMode::HalfUp,
+    });
 
     if round_income {
         *income = round_by_rule(*income, jpy_rule);
@@ -265,15 +263,14 @@ fn apply_per_event_rounding(
     }
 }
 
-fn apply_per_year_rounding_to_asset_summary(summary: &mut YearlyAssetSummary, policy: &RoundingPolicy) {
-    let jpy_rule = policy
-        .currency
-        .get("JPY")
-        .copied()
-        .unwrap_or(RoundRule {
-            scale: 0,
-            mode: RoundingMode::HalfUp,
-        });
+fn apply_per_year_rounding_to_asset_summary(
+    summary: &mut YearlyAssetSummary,
+    policy: &RoundingPolicy,
+) {
+    let jpy_rule = policy.currency.get("JPY").copied().unwrap_or(RoundRule {
+        scale: 0,
+        mode: RoundingMode::HalfUp,
+    });
 
     summary.carry_in_qty = round_by_rule(summary.carry_in_qty, policy.quantity);
     summary.carry_in_cost = round_by_rule(summary.carry_in_cost, jpy_rule);

--- a/eupholio-core/src/event.rs
+++ b/eupholio-core/src/event.rs
@@ -60,4 +60,3 @@ impl Event {
         }
     }
 }
-

--- a/eupholio-core/src/lib.rs
+++ b/eupholio-core/src/lib.rs
@@ -42,7 +42,12 @@ pub fn calculate_total_average_with_carry(
     events: &[Event],
     carry_in: &HashMap<String, CarryIn>,
 ) -> Report {
-    calculate_total_average_with_carry_and_rounding(tax_year, events, carry_in, RoundingPolicy::default())
+    calculate_total_average_with_carry_and_rounding(
+        tax_year,
+        events,
+        carry_in,
+        RoundingPolicy::default(),
+    )
 }
 
 pub fn calculate_total_average_with_carry_and_rounding(
@@ -69,14 +74,10 @@ fn apply_rounding(report: &mut Report, policy: &RoundingPolicy) {
         return;
     }
 
-    let jpy_rule = policy
-        .currency
-        .get("JPY")
-        .copied()
-        .unwrap_or(RoundRule {
-            scale: 0,
-            mode: RoundingMode::HalfUp,
-        });
+    let jpy_rule = policy.currency.get("JPY").copied().unwrap_or(RoundRule {
+        scale: 0,
+        mode: RoundingMode::HalfUp,
+    });
 
     report.realized_pnl_jpy = round_by_rule(report.realized_pnl_jpy, jpy_rule);
     report.income_jpy = round_by_rule(report.income_jpy, jpy_rule);

--- a/eupholio-core/tests/cli_e2e.rs
+++ b/eupholio-core/tests/cli_e2e.rs
@@ -104,9 +104,7 @@ fn cli_validate_per_year_total_average_no_timing_warning() {
         .assert()
         .success()
         .stdout(predicate::str::contains("ROUNDING_TIMING_NOT_FULLY_IMPLEMENTED").not())
-        .stdout(
-            predicate::str::contains("ROUNDING_PER_YEAR_UNSUPPORTED_FOR_MOVING_AVERAGE").not(),
-        );
+        .stdout(predicate::str::contains("ROUNDING_PER_YEAR_UNSUPPORTED_FOR_MOVING_AVERAGE").not());
 }
 
 #[test]

--- a/eupholio-core/tests/golden.rs
+++ b/eupholio-core/tests/golden.rs
@@ -373,16 +373,18 @@ fn case8_year_mismatch_is_excluded_consistently_across_methods() {
     assert_eq!(moving.positions["BTC"].qty, dec!(0));
     assert_eq!(total.positions["BTC"].qty, dec!(0));
 
-    assert!(
-        moving
-            .diagnostics
-            .iter()
-            .any(|w| matches!(w, Warning::YearMismatch { event_year: 2025, tax_year: 2026 }))
-    );
-    assert!(
-        total
-            .diagnostics
-            .iter()
-            .any(|w| matches!(w, Warning::YearMismatch { event_year: 2025, tax_year: 2026 }))
-    );
+    assert!(moving.diagnostics.iter().any(|w| matches!(
+        w,
+        Warning::YearMismatch {
+            event_year: 2025,
+            tax_year: 2026
+        }
+    )));
+    assert!(total.diagnostics.iter().any(|w| matches!(
+        w,
+        Warning::YearMismatch {
+            event_year: 2025,
+            tax_year: 2026
+        }
+    )));
 }

--- a/eupholio-core/tests/per_year_carry_consistency.rs
+++ b/eupholio-core/tests/per_year_carry_consistency.rs
@@ -59,16 +59,15 @@ fn per_year_rounding_keeps_carry_out_cost_coherent_with_qty_and_avg() {
         &events,
     );
 
-    let summary = &report
-        .yearly_summary
-        .as_ref()
-        .unwrap()
-        .by_asset["BTC"];
+    let summary = &report.yearly_summary.as_ref().unwrap().by_asset["BTC"];
 
     assert_eq!(summary.average_cost_per_unit, dec!(101));
     assert_eq!(summary.carry_out_qty, dec!(1));
     assert_eq!(summary.carry_out_cost, dec!(101));
-    assert_eq!(summary.carry_out_cost, summary.carry_out_qty * summary.average_cost_per_unit);
+    assert_eq!(
+        summary.carry_out_cost,
+        summary.carry_out_qty * summary.average_cost_per_unit
+    );
 }
 
 #[test]
@@ -110,11 +109,7 @@ fn per_year_rounding_applies_jpy_rounding_after_rounded_qty_avg_product() {
         &events,
     );
 
-    let summary = &report
-        .yearly_summary
-        .as_ref()
-        .unwrap()
-        .by_asset["BTC"];
+    let summary = &report.yearly_summary.as_ref().unwrap().by_asset["BTC"];
 
     assert_eq!(summary.carry_out_qty, dec!(1));
     assert_eq!(summary.average_cost_per_unit, dec!(100.5));

--- a/eupholio-normalizer/src/bitflyer.rs
+++ b/eupholio-normalizer/src/bitflyer.rs
@@ -105,7 +105,10 @@ pub fn normalize_transaction_history_csv(raw: &str) -> Result<NormalizeResult, S
         }
     }
 
-    Ok(NormalizeResult { events, diagnostics })
+    Ok(NormalizeResult {
+        events,
+        diagnostics,
+    })
 }
 
 fn map_row(
@@ -139,7 +142,10 @@ fn map_row(
 
     if trade_type == OP_BUY_JP || trade_type == OP_BUY_EN {
         if asset2 != "JPY" {
-            return Err(format!("unsupported payment asset '{}', only JPY is supported", asset2));
+            return Err(format!(
+                "unsupported payment asset '{}', only JPY is supported",
+                asset2
+            ));
         }
         let net_qty = qty1 + fee;
         if net_qty <= Decimal::ZERO {
@@ -155,7 +161,10 @@ fn map_row(
     }
 
     if asset2 != "JPY" {
-        return Err(format!("unsupported payment asset '{}', only JPY is supported", asset2));
+        return Err(format!(
+            "unsupported payment asset '{}', only JPY is supported",
+            asset2
+        ));
     }
     if qty1 <= Decimal::ZERO {
         return Err(format!("sell qty must be > 0, got {}", qty1));
@@ -194,7 +203,11 @@ fn build_header_index(headers: &StringRecord) -> HashMap<String, usize> {
         .collect()
 }
 
-fn get<'a>(idx: &HashMap<String, usize>, row: &'a StringRecord, key: &str) -> Result<&'a str, String> {
+fn get<'a>(
+    idx: &HashMap<String, usize>,
+    row: &'a StringRecord,
+    key: &str,
+) -> Result<&'a str, String> {
     let i = *idx
         .get(key)
         .ok_or_else(|| format!("missing required header {}", key))?;

--- a/eupholio-normalizer/src/bittrex.rs
+++ b/eupholio-normalizer/src/bittrex.rs
@@ -91,7 +91,10 @@ pub fn normalize_order_history_csv(raw: &str) -> Result<NormalizeResult, String>
     })
 }
 
-fn map_row_to_event(index: &HashMap<String, usize>, row: &StringRecord) -> Result<Option<Event>, String> {
+fn map_row_to_event(
+    index: &HashMap<String, usize>,
+    row: &StringRecord,
+) -> Result<Option<Event>, String> {
     let id = get(index, row, "Uuid")?;
     let exchange = get(index, row, "Exchange")?;
     let order_type = get(index, row, "OrderType")?;
@@ -137,7 +140,11 @@ fn build_header_index(headers: &StringRecord) -> HashMap<String, usize> {
         .collect()
 }
 
-fn get<'a>(index: &HashMap<String, usize>, row: &'a StringRecord, key: &str) -> Result<&'a str, String> {
+fn get<'a>(
+    index: &HashMap<String, usize>,
+    row: &'a StringRecord,
+    key: &str,
+) -> Result<&'a str, String> {
     let i = *index
         .get(key)
         .ok_or_else(|| format!("missing required header {}", key))?;
@@ -159,8 +166,12 @@ fn parse_datetime(s: &str) -> Result<DateTime<Utc>, String> {
 
 fn split_exchange(s: &str) -> Result<(&str, &str), String> {
     let mut parts = s.split('-');
-    let payment = parts.next().ok_or_else(|| "missing payment asset".to_string())?;
-    let trading = parts.next().ok_or_else(|| "missing trading asset".to_string())?;
+    let payment = parts
+        .next()
+        .ok_or_else(|| "missing payment asset".to_string())?;
+    let trading = parts
+        .next()
+        .ok_or_else(|| "missing trading asset".to_string())?;
     if parts.next().is_some() {
         return Err(format!("invalid exchange pair '{}'", s));
     }

--- a/eupholio-normalizer/src/coincheck.rs
+++ b/eupholio-normalizer/src/coincheck.rs
@@ -68,7 +68,9 @@ pub fn normalize_trade_history_csv(raw: &str) -> Result<NormalizeResult, String>
 
         match map_row(&header_index, &record) {
             Ok(RowOutcome::Event(event)) => events.push(event),
-            Ok(RowOutcome::Unsupported(reason)) => diagnostics.push(NormalizeDiagnostic { row, reason }),
+            Ok(RowOutcome::Unsupported(reason)) => {
+                diagnostics.push(NormalizeDiagnostic { row, reason })
+            }
             Err(e) => return Err(format!("row {}: {}", row, e)),
         }
     }
@@ -200,7 +202,11 @@ fn build_header_index(headers: &StringRecord) -> HashMap<String, usize> {
         .collect()
 }
 
-fn get<'a>(index: &HashMap<String, usize>, row: &'a StringRecord, key: &str) -> Result<&'a str, String> {
+fn get<'a>(
+    index: &HashMap<String, usize>,
+    row: &'a StringRecord,
+    key: &str,
+) -> Result<&'a str, String> {
     let i = *index
         .get(key)
         .ok_or_else(|| format!("missing required header {}", key))?;
@@ -235,9 +241,12 @@ fn parse_rate_pair(comment: &str) -> Result<(Decimal, String, String), String> {
             .expect("regex should compile")
     });
 
-    let caps = re
-        .captures(comment)
-        .ok_or_else(|| format!("failed to parse comment: {}", sanitize_diagnostic_value(comment)))?;
+    let caps = re.captures(comment).ok_or_else(|| {
+        format!(
+            "failed to parse comment: {}",
+            sanitize_diagnostic_value(comment)
+        )
+    })?;
     let rate = parse_decimal(&caps[1])?;
     let quote = caps[2].to_ascii_uppercase();
     let base = caps[3].to_ascii_uppercase();

--- a/eupholio-normalizer/tests/normalizer_bitflyer_smoke.rs
+++ b/eupholio-normalizer/tests/normalizer_bitflyer_smoke.rs
@@ -5,7 +5,8 @@ use eupholio_normalizer::bitflyer::normalize_transaction_history_csv;
 #[test]
 fn bitflyer_smoke_source_to_normalized_to_calculate() {
     let raw = include_str!("fixtures/normalizer/bitflyer_transaction_history_smoke.csv");
-    let expected_raw = include_str!("fixtures/normalizer/bitflyer_transaction_history_smoke.normalized.json");
+    let expected_raw =
+        include_str!("fixtures/normalizer/bitflyer_transaction_history_smoke.normalized.json");
 
     let normalized = normalize_transaction_history_csv(raw).expect("normalization should succeed");
     assert_eq!(normalized.diagnostics.len(), 1);
@@ -15,7 +16,8 @@ fn bitflyer_smoke_source_to_normalized_to_calculate() {
         "unsupported trade type: trade_type='入金', order_id='bf-order-003'"
     );
 
-    let expected: Vec<Event> = serde_json::from_str(expected_raw).expect("fixture json should be valid");
+    let expected: Vec<Event> =
+        serde_json::from_str(expected_raw).expect("fixture json should be valid");
     assert_eq!(normalized.events, expected);
 
     let report = eupholio_core::calculate(

--- a/eupholio-normalizer/tests/normalizer_bittrex_smoke.rs
+++ b/eupholio-normalizer/tests/normalizer_bittrex_smoke.rs
@@ -5,18 +5,27 @@ use eupholio_normalizer::bittrex::normalize_order_history_csv;
 #[test]
 fn bittrex_smoke_source_to_normalized_to_calculate() {
     let raw = include_str!("fixtures/normalizer/bittrex_order_history_smoke.csv");
-    let expected_raw = include_str!("fixtures/normalizer/bittrex_order_history_smoke.normalized.json");
+    let expected_raw =
+        include_str!("fixtures/normalizer/bittrex_order_history_smoke.normalized.json");
 
     let normalized = normalize_order_history_csv(raw).expect("normalization should succeed");
-    assert_eq!(normalized.diagnostics.len(), 1, "unsupported rows are diagnosed");
+    assert_eq!(
+        normalized.diagnostics.len(),
+        1,
+        "unsupported rows are diagnosed"
+    );
     assert_eq!(normalized.diagnostics[0].row, 4);
     assert_eq!(
         normalized.diagnostics[0].reason,
         "unsupported order type: OrderType='UNKNOWN', Uuid='skip-001'"
     );
 
-    let expected: Vec<Event> = serde_json::from_str(expected_raw).expect("fixture json should be valid");
-    assert_eq!(normalized.events, expected, "normalized output should match fixture");
+    let expected: Vec<Event> =
+        serde_json::from_str(expected_raw).expect("fixture json should be valid");
+    assert_eq!(
+        normalized.events, expected,
+        "normalized output should match fixture"
+    );
 
     let report = eupholio_core::calculate(
         Config {
@@ -29,7 +38,10 @@ fn bittrex_smoke_source_to_normalized_to_calculate() {
 
     assert_eq!(report.realized_pnl_jpy.to_string(), "198800");
     assert_eq!(report.positions.len(), 1);
-    let btc = report.positions.get("BTC").expect("btc position should exist");
+    let btc = report
+        .positions
+        .get("BTC")
+        .expect("btc position should exist");
     assert_eq!(btc.qty.to_string(), "0.0");
 }
 

--- a/eupholio-normalizer/tests/normalizer_coincheck_smoke.rs
+++ b/eupholio-normalizer/tests/normalizer_coincheck_smoke.rs
@@ -10,8 +10,12 @@ fn coincheck_smoke_source_to_normalized_to_calculate() {
     let normalized = normalize_trade_history_csv(raw).expect("normalization should succeed");
     assert!(normalized.diagnostics.is_empty());
 
-    let expected: Vec<Event> = serde_json::from_str(expected_raw).expect("fixture json should be valid");
-    assert_eq!(normalized.events, expected, "normalized output should match fixture");
+    let expected: Vec<Event> =
+        serde_json::from_str(expected_raw).expect("fixture json should be valid");
+    assert_eq!(
+        normalized.events, expected,
+        "normalized output should match fixture"
+    );
 
     let report = eupholio_core::calculate(
         Config {
@@ -23,7 +27,10 @@ fn coincheck_smoke_source_to_normalized_to_calculate() {
     );
 
     assert_eq!(report.realized_pnl_jpy.to_string(), "198800");
-    let btc = report.positions.get("BTC").expect("btc position should exist");
+    let btc = report
+        .positions
+        .get("BTC")
+        .expect("btc position should exist");
     assert_eq!(btc.qty.to_string(), "0.0");
 }
 
@@ -38,9 +45,7 @@ cc1,2026-01-01 00:00:00 +0900,Completed trading contracts,\"1,000\",JPY,,,,\"Rat
 
     match &normalized.events[0] {
         Event::Dispose {
-            qty,
-            jpy_proceeds,
-            ..
+            qty, jpy_proceeds, ..
         } => {
             assert_eq!(qty.to_string(), "0.1");
             assert_eq!(jpy_proceeds.to_string(), "1000");
@@ -57,7 +62,8 @@ cc1,2026-01-01 00:00:00 +0900,Completed trading contracts,1,BTC,,,0\n";
         .expect_err("missing header should fail")
         .contains("missing required header comment"));
 
-    let bad_comment = "id,time,operation,amount,trading_currency,price,original_currency,fee,comment\n\
+    let bad_comment =
+        "id,time,operation,amount,trading_currency,price,original_currency,fee,comment\n\
 cc2,2026-01-01 00:00:00 +0900,Completed trading contracts,1,BTC,,,0,broken\n";
     assert!(normalize_trade_history_csv(bad_comment)
         .expect_err("bad comment should fail")


### PR DESCRIPTION
## Summary
- add format workflow for PRs and main pushes
- enforce Rust formatting with cargo fmt --all -- --check
- enforce Go formatting with gofmt -l across all Go files

## Why
- prevent formatting regressions
- keep code style checks automatic and consistent