### PR TITLE
feat(normalizer): bitFlyer API phase-1 normalization PoC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "borsh"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +286,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +330,17 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "equivalent"
@@ -330,9 +369,13 @@ dependencies = [
  "chrono",
  "csv",
  "eupholio-core",
+ "hex",
+ "hmac",
  "regex",
  "rust_decimal",
+ "serde",
  "serde_json",
+ "sha2",
 ]
 
 [[package]]
@@ -355,6 +398,16 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -387,6 +440,21 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -766,6 +834,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +861,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -861,6 +946,12 @@ checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"

--- a/eupholio-normalizer/Cargo.toml
+++ b/eupholio-normalizer/Cargo.toml
@@ -9,6 +9,10 @@ rust_decimal = { version = "1", features = ["serde"] }
 eupholio-core = { path = "../eupholio-core" }
 csv = "1"
 regex = "1"
+serde = { version = "1", features = ["derive"] }
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
 
 [dev-dependencies]
 serde_json = "1"

--- a/eupholio-normalizer/src/bitflyer_api.rs
+++ b/eupholio-normalizer/src/bitflyer_api.rs
@@ -1,0 +1,112 @@
+use chrono::{DateTime, Utc};
+use eupholio_core::event::Event;
+use hmac::{Hmac, Mac};
+use rust_decimal::Decimal;
+use serde::Deserialize;
+use sha2::Sha256;
+
+use crate::bitflyer::{NormalizeDiagnostic, NormalizeResult};
+
+type HmacSha256 = Hmac<Sha256>;
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct Execution {
+    pub id: i64,
+    pub side: String,
+    pub price: Decimal,
+    pub size: Decimal,
+    pub exec_date: DateTime<Utc>,
+    #[serde(default)]
+    pub commission: Option<Decimal>,
+}
+
+pub fn sign_request(secret: &str, timestamp: &str, method: &str, path: &str, body: &str) -> String {
+    let payload = format!("{}{}{}{}", timestamp, method, path, body);
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).expect("hmac init should succeed");
+    mac.update(payload.as_bytes());
+    let bytes = mac.finalize().into_bytes();
+    hex::encode(bytes)
+}
+
+pub fn normalize_executions(
+    executions: &[Execution],
+    product_code: &str,
+) -> Result<NormalizeResult, String> {
+    let (base_asset, quote_asset) = split_product(product_code)?;
+    if quote_asset != "JPY" {
+        return Err(format!(
+            "unsupported quote asset '{}', only JPY is supported in phase-1",
+            quote_asset
+        ));
+    }
+
+    let mut events = Vec::new();
+    let mut diagnostics = Vec::new();
+
+    for (i, ex) in executions.iter().enumerate() {
+        let row = i + 1;
+        if ex.size <= Decimal::ZERO {
+            return Err(format!("row {}: size must be > 0, got {}", row, ex.size));
+        }
+        if ex.price <= Decimal::ZERO {
+            return Err(format!("row {}: price must be > 0, got {}", row, ex.price));
+        }
+
+        let fee = ex.commission.unwrap_or(Decimal::ZERO).abs();
+        let jpy_total = ex.price * ex.size;
+
+        match ex.side.as_str() {
+            "BUY" => {
+                let net_qty = ex.size - fee;
+                if net_qty <= Decimal::ZERO {
+                    return Err(format!(
+                        "row {}: buy qty must be > 0 after fee, got {}",
+                        row, net_qty
+                    ));
+                }
+                events.push(Event::Acquire {
+                    id: format!("bfexec-{}:acquire", ex.id),
+                    asset: base_asset.to_string(),
+                    qty: net_qty,
+                    jpy_cost: jpy_total,
+                    ts: ex.exec_date,
+                });
+            }
+            "SELL" => {
+                events.push(Event::Dispose {
+                    id: format!("bfexec-{}:dispose", ex.id),
+                    asset: base_asset.to_string(),
+                    qty: ex.size,
+                    jpy_proceeds: jpy_total - fee,
+                    ts: ex.exec_date,
+                });
+            }
+            other => diagnostics.push(NormalizeDiagnostic {
+                row,
+                reason: format!(
+                    "unsupported side: side='{}', execution_id='{}'",
+                    other, ex.id
+                ),
+            }),
+        }
+    }
+
+    Ok(NormalizeResult {
+        events,
+        diagnostics,
+    })
+}
+
+fn split_product(product_code: &str) -> Result<(&str, &str), String> {
+    let mut parts = product_code.split('_');
+    let base = parts
+        .next()
+        .ok_or_else(|| format!("invalid product_code '{}': missing base", product_code))?;
+    let quote = parts
+        .next()
+        .ok_or_else(|| format!("invalid product_code '{}': missing quote", product_code))?;
+    if parts.next().is_some() {
+        return Err(format!("invalid product_code '{}'", product_code));
+    }
+    Ok((base, quote))
+}

--- a/eupholio-normalizer/src/lib.rs
+++ b/eupholio-normalizer/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bitflyer;
+pub mod bitflyer_api;
 pub mod bittrex;
 pub mod coincheck;
 pub mod poloniex;

--- a/eupholio-normalizer/tests/bitflyer_api_poc.rs
+++ b/eupholio-normalizer/tests/bitflyer_api_poc.rs
@@ -1,0 +1,76 @@
+use eupholio_core::event::Event;
+use eupholio_normalizer::bitflyer_api::{normalize_executions, sign_request, Execution};
+
+#[test]
+fn bitflyer_api_sign_request_is_deterministic() {
+    let sign = sign_request(
+        "secret",
+        "1700000000",
+        "GET",
+        "/v1/me/getexecutions?product_code=BTC_JPY&count=100",
+        "",
+    );
+    assert_eq!(
+        sign,
+        "3a8a2a40c61b15c6014722eee597a2a111f35d22ba2999e4bc04310a946f9719"
+    );
+}
+
+#[test]
+fn bitflyer_api_normalize_executions_to_events() {
+    let raw = r#"[
+      {"id": 1001, "side": "BUY", "price": "1000000", "size": "0.01", "exec_date": "2026-01-01T00:00:00Z", "commission": "0.0001"},
+      {"id": 1002, "side": "SELL", "price": "1200000", "size": "0.005", "exec_date": "2026-01-02T00:00:00Z", "commission": "120"},
+      {"id": 1003, "side": "OTHER", "price": "1", "size": "1", "exec_date": "2026-01-03T00:00:00Z"}
+    ]"#;
+
+    let executions: Vec<Execution> = serde_json::from_str(raw).expect("json should parse");
+    let normalized =
+        normalize_executions(&executions, "BTC_JPY").expect("normalization should work");
+
+    assert_eq!(normalized.events.len(), 2);
+    assert_eq!(normalized.diagnostics.len(), 1);
+    assert!(normalized.diagnostics[0]
+        .reason
+        .contains("unsupported side"));
+
+    match &normalized.events[0] {
+        Event::Acquire {
+            id,
+            asset,
+            qty,
+            jpy_cost,
+            ..
+        } => {
+            assert_eq!(id, "bfexec-1001:acquire");
+            assert_eq!(asset, "BTC");
+            assert_eq!(qty.to_string(), "0.0099");
+            assert_eq!(jpy_cost.to_string(), "10000.00");
+        }
+        _ => panic!("expected acquire"),
+    }
+
+    match &normalized.events[1] {
+        Event::Dispose {
+            id,
+            asset,
+            qty,
+            jpy_proceeds,
+            ..
+        } => {
+            assert_eq!(id, "bfexec-1002:dispose");
+            assert_eq!(asset, "BTC");
+            assert_eq!(qty.to_string(), "0.005");
+            assert_eq!(jpy_proceeds.to_string(), "5880.000");
+        }
+        _ => panic!("expected dispose"),
+    }
+}
+
+#[test]
+fn bitflyer_api_non_jpy_quote_is_rejected() {
+    let executions: Vec<Execution> = serde_json::from_str("[]").unwrap();
+    assert!(normalize_executions(&executions, "BTC_USD")
+        .expect_err("non-jpy should fail")
+        .contains("only JPY is supported"));
+}


### PR DESCRIPTION
## Summary
- add bitflyer_api module for phase-1 PoC foundation
- add private API request signer (ACCESS-SIGN) using HMAC-SHA256
- add execution payload model + normalization into Event Acquire/Dispose
- add diagnostics for unsupported side
- enforce JPY quote-only in phase-1
- add PoC tests (signing, normalization, non-JPY rejection)

## Validation
- cargo test -p eupholio-normalizer --test bitflyer_api_poc
- cargo test -p eupholio-normalizer