### PR TITLE
feat(normalizer): wire bitFlyer fetch to normalize+calculate flow

### DIFF
--- a/eupholio-normalizer/src/bitflyer_api.rs
+++ b/eupholio-normalizer/src/bitflyer_api.rs
@@ -144,6 +144,11 @@ impl BitflyerApiClient {
 
         Err("unreachable retry loop".to_string())
     }
+
+    pub fn fetch_and_normalize_page(&self, opts: &FetchOptions) -> Result<NormalizeResult, String> {
+        let executions = self.fetch_executions_page(opts)?;
+        normalize_executions(&executions, &opts.product_code)
+    }
 }
 
 pub fn sign_request(secret: &str, timestamp: &str, method: &str, path: &str, body: &str) -> String {


### PR DESCRIPTION
## Summary
- add  to bitFlyer API client
- update PoC CLI to execute end-to-end flow:
  1. fetch executions from bitFlyer API
  2. normalize to events
  3. run 
  4. print realized/income/position summary
- keep existing unit/integration tests green

## Usage


## Validation
- cargo test -p eupholio-normalizer --test bitflyer_api_poc
- cargo test -p eupholio-normalizer
