### PR TITLE
feat(normalizer): export bitFlyer API outputs to JSON

### DIFF
--- a/eupholio-normalizer/Cargo.toml
+++ b/eupholio-normalizer/Cargo.toml
@@ -14,6 +14,6 @@ hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+serde_json = "1"
 
 [dev-dependencies]
-serde_json = "1"

--- a/eupholio-normalizer/src/bin/bitflyer-api-poc.rs
+++ b/eupholio-normalizer/src/bin/bitflyer-api-poc.rs
@@ -1,8 +1,11 @@
+use std::fs;
+use std::path::PathBuf;
 use std::process;
 
 use chrono::{DateTime, Utc};
 use eupholio_core::config::{Config, CostMethod};
 use eupholio_normalizer::bitflyer_api::{BitflyerApiClient, FetchWindowOptions};
+use serde_json::json;
 
 fn main() {
     if let Err(err) = run() {
@@ -27,6 +30,7 @@ fn run() -> Result<(), String> {
         .unwrap_or(2026);
     let since = parse_dt(args.get(4).map(String::as_str))?;
     let until = parse_dt(args.get(5).map(String::as_str))?;
+    let out_dir = args.get(6).map(PathBuf::from);
 
     let opts = FetchWindowOptions {
         product_code,
@@ -57,6 +61,60 @@ fn run() -> Result<(), String> {
     println!("realized_pnl_jpy={}", report.realized_pnl_jpy);
     println!("income_jpy={}", report.income_jpy);
     println!("positions={}", report.positions.len());
+
+    if let Some(dir) = out_dir {
+        fs::create_dir_all(&dir).map_err(|e| format!("failed to create out dir: {e}"))?;
+
+        let events_path = dir.join("events.json");
+        let diagnostics_path = dir.join("diagnostics.json");
+        let report_path = dir.join("report.json");
+        let meta_path = dir.join("meta.json");
+
+        fs::write(
+            &events_path,
+            serde_json::to_vec_pretty(&normalized.events)
+                .map_err(|e| format!("failed to encode events json: {e}"))?,
+        )
+        .map_err(|e| format!("failed to write events json: {e}"))?;
+
+        fs::write(
+            &diagnostics_path,
+            serde_json::to_vec_pretty(&normalized.diagnostics)
+                .map_err(|e| format!("failed to encode diagnostics json: {e}"))?,
+        )
+        .map_err(|e| format!("failed to write diagnostics json: {e}"))?;
+
+        fs::write(
+            &report_path,
+            serde_json::to_vec_pretty(&report)
+                .map_err(|e| format!("failed to encode report json: {e}"))?,
+        )
+        .map_err(|e| format!("failed to write report json: {e}"))?;
+
+        let meta = json!({
+            "product_code": opts.product_code,
+            "tax_year": tax_year,
+            "count_per_page": opts.count_per_page,
+            "max_pages": opts.max_pages,
+            "since": opts.since,
+            "until": opts.until,
+            "generated_at": Utc::now(),
+            "files": {
+                "events": events_path,
+                "diagnostics": diagnostics_path,
+                "report": report_path
+            }
+        });
+
+        fs::write(
+            &meta_path,
+            serde_json::to_vec_pretty(&meta)
+                .map_err(|e| format!("failed to encode meta json: {e}"))?,
+        )
+        .map_err(|e| format!("failed to write meta json: {e}"))?;
+
+        println!("exported json to {}", dir.display());
+    }
 
     Ok(())
 }

--- a/eupholio-normalizer/src/bitflyer.rs
+++ b/eupholio-normalizer/src/bitflyer.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use csv::StringRecord;
 use eupholio_core::event::Event;
 use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str::FromStr;
 
@@ -43,7 +44,7 @@ const HEADERS_EN: &[&str] = &[
     "Details",
 ];
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NormalizeDiagnostic {
     pub row: usize,
     pub reason: String,


### PR DESCRIPTION
## Summary
- extend bitflyer-api-poc CLI with optional output directory arg
- save `events.json`, `diagnostics.json`, `report.json`, and `meta.json`
- add serde derive for NormalizeDiagnostic serialization support

## Usage
BITFLYER_API_KEY=... BITFLYER_API_SECRET=... \
  cargo run -p eupholio-normalizer --bin bitflyer-api-poc -- \
  BTC_JPY 100 2026 2026-01-01T00:00:00Z 2026-12-31T23:59:59Z ./out/bitflyer-2026

## Validation
- cargo test -p eupholio-normalizer
