### PR TITLE
fix(normalizer): resolve remaining Copilot follow-ups for bitFlyer API

### DIFF
--- a/eupholio-normalizer/src/bin/bitflyer-api-poc.rs
+++ b/eupholio-normalizer/src/bin/bitflyer-api-poc.rs
@@ -41,7 +41,7 @@ fn run() -> Result<(), String> {
     };
 
     let client = BitflyerApiClient::from_env()?;
-    let normalized = client.fetch_normalize_window(&opts)?;
+    let normalized = client.fetch_and_normalize_window(&opts)?;
 
     println!(
         "normalized: events={} diagnostics={}",

--- a/eupholio-normalizer/src/bitflyer_api.rs
+++ b/eupholio-normalizer/src/bitflyer_api.rs
@@ -112,8 +112,7 @@ impl BitflyerApiClient {
     }
 
     pub fn fetch_executions_page(&self, opts: &FetchOptions) -> Result<Vec<Execution>, String> {
-        validate_product_code(&opts.product_code)?;
-        let path_with_query = build_executions_path(opts);
+        let path_with_query = build_executions_path(opts)?;
         let url = format!("{}{}", self.base_url, path_with_query);
 
         let mut backoff = Duration::from_millis(300);
@@ -306,9 +305,8 @@ pub fn filter_executions_by_time(
         .collect()
 }
 
-pub fn build_executions_path(opts: &FetchOptions) -> String {
-    let product_code =
-        validate_product_code(&opts.product_code).unwrap_or_else(|_| opts.product_code.clone());
+pub fn build_executions_path(opts: &FetchOptions) -> Result<String, String> {
+    let product_code = validate_product_code(&opts.product_code)?;
 
     let mut q = vec![
         format!("product_code={}", product_code),
@@ -322,7 +320,7 @@ pub fn build_executions_path(opts: &FetchOptions) -> String {
         q.push(format!("after={}", v));
     }
 
-    format!("{}?{}", EXECUTIONS_PATH, q.join("&"))
+    Ok(format!("{}?{}", EXECUTIONS_PATH, q.join("&")))
 }
 
 fn build_auth_headers(api_key: &str, timestamp: &str, sign: &str) -> Result<HeaderMap, String> {

--- a/eupholio-normalizer/src/bitflyer_api.rs
+++ b/eupholio-normalizer/src/bitflyer_api.rs
@@ -307,6 +307,9 @@ pub fn filter_executions_by_time(
 
 pub fn build_executions_path(opts: &FetchOptions) -> Result<String, String> {
     let product_code = validate_product_code(&opts.product_code)?;
+    if opts.count == 0 {
+        return Err("count must be > 0".to_string());
+    }
 
     let mut q = vec![
         format!("product_code={}", product_code),

--- a/eupholio-normalizer/tests/bitflyer_api_poc.rs
+++ b/eupholio-normalizer/tests/bitflyer_api_poc.rs
@@ -94,6 +94,18 @@ fn bitflyer_api_build_executions_path_with_paging() {
 }
 
 #[test]
+fn bitflyer_api_build_executions_path_rejects_zero_count() {
+    let err = build_executions_path(&FetchOptions {
+        product_code: "BTC_JPY".to_string(),
+        count: 0,
+        before: None,
+        after: None,
+    })
+    .expect_err("count=0 should fail");
+    assert!(err.contains("count must be > 0"));
+}
+
+#[test]
 fn bitflyer_api_filter_executions_by_time_window() {
     let raw = r#"[
       {"id": 1, "side": "BUY", "price": "100", "size": "1", "exec_date": "2026-01-01T00:00:00Z"},

--- a/eupholio-normalizer/tests/bitflyer_api_poc.rs
+++ b/eupholio-normalizer/tests/bitflyer_api_poc.rs
@@ -84,7 +84,8 @@ fn bitflyer_api_build_executions_path_with_paging() {
         count: 100,
         before: Some(123),
         after: Some(45),
-    });
+    })
+    .expect("path should build");
 
     assert_eq!(
         path,

--- a/eupholio-normalizer/tests/bitflyer_api_poc.rs
+++ b/eupholio-normalizer/tests/bitflyer_api_poc.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use eupholio_core::event::Event;
 use eupholio_normalizer::bitflyer_api::{
     build_executions_path, filter_executions_by_time, normalize_executions, sign_request,
-    Execution, FetchOptions,
+    ApiCredentials, BitflyerApiClient, Execution, FetchOptions, FetchWindowOptions,
 };
 
 #[test]
@@ -25,7 +25,7 @@ fn bitflyer_api_normalize_executions_to_events() {
     let raw = r#"[
       {"id": 1001, "side": "BUY", "price": "1000000", "size": "0.01", "exec_date": "2026-01-01T00:00:00Z", "commission": "0.0001"},
       {"id": 1002, "side": "SELL", "price": "1200000", "size": "0.005", "exec_date": "2026-01-02T00:00:00Z", "commission": "0.0001"},
-      {"id": 1003, "side": "OTHER", "price": "1", "size": "1", "exec_date": "2026-01-03T00:00:00Z"}
+      {"id": 1003, "side": "  oThEr  ", "price": "1", "size": "1", "exec_date": "2026-01-03T00:00:00Z"}
     ]"#;
 
     let executions: Vec<Execution> = serde_json::from_str(raw).expect("json should parse");
@@ -34,9 +34,7 @@ fn bitflyer_api_normalize_executions_to_events() {
 
     assert_eq!(normalized.events.len(), 2);
     assert_eq!(normalized.diagnostics.len(), 1);
-    assert!(normalized.diagnostics[0]
-        .reason
-        .contains("unsupported side"));
+    assert!(normalized.diagnostics[0].reason.contains("side='oThEr'"));
 
     match &normalized.events[0] {
         Event::Acquire {
@@ -113,4 +111,36 @@ fn bitflyer_api_filter_executions_by_time_window() {
     let filtered = filter_executions_by_time(&executions, Some(since), Some(until));
     assert_eq!(filtered.len(), 1);
     assert_eq!(filtered[0].id, 2);
+}
+
+#[test]
+fn bitflyer_api_window_rejects_invalid_since_until() {
+    let client = BitflyerApiClient::new(
+        "https://api.bitflyer.com/".to_string(),
+        ApiCredentials {
+            api_key: "k".to_string(),
+            api_secret: "s".to_string(),
+        },
+    )
+    .expect("client should construct");
+
+    let since = DateTime::parse_from_rfc3339("2026-02-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let until = DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    let err = client
+        .fetch_executions_window(&FetchWindowOptions {
+            product_code: "BTC_JPY".to_string(),
+            count_per_page: 100,
+            max_pages: 1,
+            since: Some(since),
+            until: Some(until),
+        })
+        .expect_err("since > until should fail before network");
+
+    assert!(err.contains("since"));
+    assert!(err.contains("until"));
 }


### PR DESCRIPTION
## Summary
Batch follow-up for unresolved Copilot comments across PR #28/#29/#30/#32.

### Implemented
- validate fetch window (`since <= until`, positive page params)
- remove timestamp-based early-stop assumption in pagination
- rename API for consistency: `fetch_and_normalize_window`
- normalize `base_url` by trimming trailing `/`
- avoid logging response body for non-success API errors
- use case-insensitive side checks without per-row uppercase allocation
- preserve original `side` text in diagnostics
- make clone intent explicit for `base_asset`
- add/extend tests for:
  - invalid since/until guard
  - diagnostics preserving original side text
  - existing path/filter/normalize behavior

## Validation
- cargo test -p eupholio-normalizer --test bitflyer_api_poc
- cargo test -p eupholio-normalizer
