### PR TITLE
fix(httputil): remove insecure TLS InsecureSkipVerify

### DIFF
--- a/pkg/httputil/get.go
+++ b/pkg/httputil/get.go
@@ -22,7 +22,6 @@ package httputil
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -42,13 +41,7 @@ func HttpGet(ctx context.Context, url string, timeout time.Duration) (content []
 	defer cancel_func()
 	request = request.WithContext(ctx)
 
-	// TODO
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-	client := &http.Client{
-		Transport: tr,
-	}
+	client := &http.Client{}
 
 	response, err := client.Do(request)
 	if err != nil {


### PR DESCRIPTION
## Summary
Start next feature track with a security hardening cleanup in shared HTTP utility.

## Changes
- remove `InsecureSkipVerify: true` from `pkg/httputil/HttpGet`
- use default HTTP client TLS verification behavior

## Why
Disabling TLS certificate verification is insecure and can allow MITM interception. Default verification is the safe baseline.

## Notes
- no call-site API changes
- if a self-signed endpoint is ever required, that should be opt-in and explicit at call sites
