### PR TITLE
fix(ops): relax pr_watchdog REPO regex for dotted names

### DIFF
--- a/scripts/pr_watchdog.sh
+++ b/scripts/pr_watchdog.sh
@@ -10,7 +10,7 @@ REVIEW_AUDIT_SCRIPT="${REVIEW_AUDIT_SCRIPT:-$REPO_ROOT/scripts/pr_review_threads
 REVIEW_AUDIT_LIMIT="${REVIEW_AUDIT_LIMIT:-20}"
 REVIEW_AUDIT_MAX_LINES="${REVIEW_AUDIT_MAX_LINES:-40}"
 
-if ! [[ "$REPO" =~ ^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+$ ]]; then
+if ! [[ "$REPO" =~ ^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$ ]]; then
   echo "Invalid REPO format: '$REPO'. Expected 'owner/name'." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
Allow valid GitHub repository names containing dots in `scripts/pr_watchdog.sh` REPO validation.

## Change
- validation regex updated from `[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+` to `[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+`

## Why
GitHub owner/repo names can include dots (e.g. `org/foo.bar`). The previous regex rejected valid repos.
