### PR TITLE
feat(normalizer): add cryptact phase-1 BUY/SELL adapter

### DIFF
--- a/eupholio-normalizer/src/cryptact.rs
+++ b/eupholio-normalizer/src/cryptact.rs
@@ -1,0 +1,192 @@
+use chrono::{DateTime, NaiveDateTime, Utc};
+use csv::StringRecord;
+use eupholio_core::event::Event;
+use rust_decimal::Decimal;
+use std::collections::HashMap;
+use std::str::FromStr;
+
+const TS_LAYOUT: &str = "%Y/%-m/%-d %H:%M:%S";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NormalizeDiagnostic {
+    pub row: usize,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NormalizeResult {
+    pub events: Vec<Event>,
+    pub diagnostics: Vec<NormalizeDiagnostic>,
+}
+
+enum RowOutcome {
+    Event(Event),
+    Unsupported(String),
+}
+
+pub fn normalize_custom_csv(raw: &str) -> Result<NormalizeResult, String> {
+    let mut rdr = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .trim(csv::Trim::All)
+        .from_reader(raw.as_bytes());
+
+    let headers = rdr
+        .headers()
+        .map_err(|e| format!("invalid csv header: {}", e))?
+        .clone();
+    let index = build_header_index(&headers);
+
+    let mut events = Vec::new();
+    let mut diagnostics = Vec::new();
+
+    for (i, result) in rdr.records().enumerate() {
+        let row = i + 2;
+        let record = result.map_err(|e| format!("row {}: invalid csv row: {}", row, e))?;
+        if record.iter().all(|v| v.trim().is_empty()) {
+            continue;
+        }
+
+        match map_row(&index, &record) {
+            Ok(RowOutcome::Event(e)) => events.push(e),
+            Ok(RowOutcome::Unsupported(reason)) => {
+                diagnostics.push(NormalizeDiagnostic { row, reason })
+            }
+            Err(e) => return Err(format!("row {}: {}", row, e)),
+        }
+    }
+
+    Ok(NormalizeResult {
+        events,
+        diagnostics,
+    })
+}
+
+fn map_row(index: &HashMap<String, usize>, row: &StringRecord) -> Result<RowOutcome, String> {
+    let ts = parse_datetime(get(index, row, "Timestamp")?)?;
+    let action = get(index, row, "Action")?.to_ascii_uppercase();
+    let id_base = build_id_base(
+        get(index, row, "Timestamp")?,
+        get(index, row, "Source")?,
+        get(index, row, "Base")?,
+        get(index, row, "Counter")?,
+    );
+
+    let base_asset = get(index, row, "Base")?.to_ascii_uppercase();
+    let qty = parse_decimal(get(index, row, "Volume")?)?;
+    if qty <= Decimal::ZERO {
+        return Err(format!("volume must be > 0, got {}", qty));
+    }
+
+    let counter = get(index, row, "Counter")?.to_ascii_uppercase();
+    let price = parse_optional_decimal(get(index, row, "Price")?)?.unwrap_or(Decimal::ZERO);
+    let fee = parse_optional_decimal(get(index, row, "Fee")?)?.unwrap_or(Decimal::ZERO);
+    let fee_ccy = get(index, row, "FeeCcy")?.to_ascii_uppercase();
+
+    if counter != "JPY" {
+        return Ok(RowOutcome::Unsupported(format!(
+            "unsupported counter currency: counter='{}', action='{}'",
+            counter, action
+        )));
+    }
+
+    match action.as_str() {
+        "BUY" => {
+            if fee_ccy != counter && fee_ccy != base_asset {
+                return Ok(RowOutcome::Unsupported(format!(
+                    "unsupported BUY fee currency: fee_ccy='{}', base='{}', counter='{}'",
+                    fee_ccy, base_asset, counter
+                )));
+            }
+
+            let jpy_cost = if fee_ccy == counter {
+                (price * qty) + fee
+            } else {
+                price * (qty + fee)
+            };
+
+            Ok(RowOutcome::Event(Event::Acquire {
+                id: format!("{}:acquire", id_base),
+                asset: base_asset,
+                qty,
+                jpy_cost,
+                ts,
+            }))
+        }
+        "SELL" => {
+            if fee_ccy != counter && fee_ccy != base_asset {
+                return Ok(RowOutcome::Unsupported(format!(
+                    "unsupported SELL fee currency: fee_ccy='{}', base='{}', counter='{}'",
+                    fee_ccy, base_asset, counter
+                )));
+            }
+
+            let jpy_proceeds = if fee_ccy == counter {
+                (price * qty) - fee
+            } else {
+                price * (qty - fee)
+            };
+
+            Ok(RowOutcome::Event(Event::Dispose {
+                id: format!("{}:dispose", id_base),
+                asset: base_asset,
+                qty,
+                jpy_proceeds,
+                ts,
+            }))
+        }
+        _ => Ok(RowOutcome::Unsupported(format!(
+            "unsupported action: action='{}'",
+            action
+        ))),
+    }
+}
+
+fn build_header_index(headers: &StringRecord) -> HashMap<String, usize> {
+    headers
+        .iter()
+        .enumerate()
+        .map(|(i, col)| (col.to_string(), i))
+        .collect()
+}
+
+fn get<'a>(
+    index: &HashMap<String, usize>,
+    row: &'a StringRecord,
+    key: &str,
+) -> Result<&'a str, String> {
+    let i = *index
+        .get(key)
+        .ok_or_else(|| format!("missing required header {}", key))?;
+    row.get(i)
+        .map(str::trim)
+        .ok_or_else(|| format!("missing required field {}", key))
+}
+
+fn parse_decimal(s: &str) -> Result<Decimal, String> {
+    let v = s.replace(',', "");
+    Decimal::from_str(&v).map_err(|e| format!("invalid decimal '{}': {}", s, e))
+}
+
+fn parse_optional_decimal(s: &str) -> Result<Option<Decimal>, String> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    parse_decimal(trimmed).map(Some)
+}
+
+fn parse_datetime(s: &str) -> Result<DateTime<Utc>, String> {
+    let dt = NaiveDateTime::parse_from_str(s, TS_LAYOUT)
+        .map_err(|e| format!("invalid datetime '{}': {}", s, e))?;
+    Ok(DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc))
+}
+
+fn build_id_base(ts: &str, source: &str, base: &str, counter: &str) -> String {
+    format!(
+        "{}:{}:{}:{}",
+        ts.trim(),
+        source.trim(),
+        base.trim().to_ascii_uppercase(),
+        counter.trim().to_ascii_uppercase()
+    )
+}

--- a/eupholio-normalizer/src/cryptact.rs
+++ b/eupholio-normalizer/src/cryptact.rs
@@ -19,8 +19,8 @@ const REQUIRED_HEADERS: [&str; 10] = [
     "Comment",
 ];
 const SUPPORTED_ACTIONS: [&str; 17] = [
-    "BUY", "SELL", "PAY", "MINING", "SENDFEE", "TIP", "REDUCE", "BONUS", "LENDING",
-    "STAKING", "LEND", "RECOVER", "BORROW", "RETURN", "LOSS", "CASH", "DEFIFEE",
+    "BUY", "SELL", "PAY", "MINING", "SENDFEE", "TIP", "REDUCE", "BONUS", "LENDING", "STAKING",
+    "LEND", "RECOVER", "BORROW", "RETURN", "LOSS", "CASH", "DEFIFEE",
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/eupholio-normalizer/src/lib.rs
+++ b/eupholio-normalizer/src/lib.rs
@@ -2,4 +2,5 @@ pub mod bitflyer;
 pub mod bitflyer_api;
 pub mod bittrex;
 pub mod coincheck;
+pub mod cryptact;
 pub mod poloniex;

--- a/eupholio-normalizer/tests/cryptact_poc.rs
+++ b/eupholio-normalizer/tests/cryptact_poc.rs
@@ -43,6 +43,16 @@ fn cryptact_normalize_buy_sell_jpy() {
 }
 
 #[test]
+fn cryptact_normalize_rejects_missing_required_header() {
+    let csv = r#"Timestamp,Action,Source,Base,Volume,Price,Counter,Fee,Comment
+2026/1/2 12:00:00,BUY,bitFlyer,BTC,0.1,6000000,JPY,120,
+"#;
+
+    let err = normalize_custom_csv(csv).expect_err("missing FeeCcy should fail");
+    assert!(err.contains("missing required header FeeCcy"));
+}
+
+#[test]
 fn cryptact_normalize_unsupported_action_to_diagnostic() {
     let csv = r#"Timestamp,Action,Source,Base,Volume,Price,Counter,Fee,FeeCcy,Comment
 2026/1/2 12:00:00,MINING,bitFlyer,BTC,0.1,0,JPY,0,JPY,

--- a/eupholio-normalizer/tests/cryptact_poc.rs
+++ b/eupholio-normalizer/tests/cryptact_poc.rs
@@ -1,0 +1,55 @@
+use eupholio_core::event::Event;
+use eupholio_normalizer::cryptact::normalize_custom_csv;
+use rust_decimal_macros::dec;
+
+#[test]
+fn cryptact_normalize_buy_sell_jpy() {
+    let csv = r#"Timestamp,Action,Source,Base,Volume,Price,Counter,Fee,FeeCcy,Comment
+2026/1/2 12:00:00,BUY,bitFlyer,BTC,0.1,6000000,JPY,120,JPY,
+2026/1/3 12:00:00,SELL,bitFlyer,BTC,0.05,6200000,JPY,100,JPY,
+"#;
+
+    let got = normalize_custom_csv(csv).expect("should parse");
+    assert_eq!(got.diagnostics.len(), 0);
+    assert_eq!(got.events.len(), 2);
+
+    match &got.events[0] {
+        Event::Acquire {
+            asset,
+            qty,
+            jpy_cost,
+            ..
+        } => {
+            assert_eq!(asset, "BTC");
+            assert_eq!(*qty, dec!(0.1));
+            assert_eq!(*jpy_cost, dec!(600120));
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
+
+    match &got.events[1] {
+        Event::Dispose {
+            asset,
+            qty,
+            jpy_proceeds,
+            ..
+        } => {
+            assert_eq!(asset, "BTC");
+            assert_eq!(*qty, dec!(0.05));
+            assert_eq!(*jpy_proceeds, dec!(309900));
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
+}
+
+#[test]
+fn cryptact_normalize_unsupported_action_to_diagnostic() {
+    let csv = r#"Timestamp,Action,Source,Base,Volume,Price,Counter,Fee,FeeCcy,Comment
+2026/1/2 12:00:00,MINING,bitFlyer,BTC,0.1,0,JPY,0,JPY,
+"#;
+
+    let got = normalize_custom_csv(csv).expect("should parse");
+    assert_eq!(got.events.len(), 0);
+    assert_eq!(got.diagnostics.len(), 1);
+    assert!(got.diagnostics[0].reason.contains("unsupported action"));
+}

--- a/eupholio-normalizer/tests/cryptact_poc.rs
+++ b/eupholio-normalizer/tests/cryptact_poc.rs
@@ -1,6 +1,7 @@
 use eupholio_core::event::Event;
 use eupholio_normalizer::cryptact::normalize_custom_csv;
-use rust_decimal_macros::dec;
+use rust_decimal::Decimal;
+use std::str::FromStr;
 
 #[test]
 fn cryptact_normalize_buy_sell_jpy() {
@@ -21,8 +22,8 @@ fn cryptact_normalize_buy_sell_jpy() {
             ..
         } => {
             assert_eq!(asset, "BTC");
-            assert_eq!(*qty, dec!(0.1));
-            assert_eq!(*jpy_cost, dec!(600120));
+            assert_eq!(*qty, d("0.1"));
+            assert_eq!(*jpy_cost, d("600120"));
         }
         other => panic!("unexpected event: {other:?}"),
     }
@@ -35,8 +36,8 @@ fn cryptact_normalize_buy_sell_jpy() {
             ..
         } => {
             assert_eq!(asset, "BTC");
-            assert_eq!(*qty, dec!(0.05));
-            assert_eq!(*jpy_proceeds, dec!(309900));
+            assert_eq!(*qty, d("0.05"));
+            assert_eq!(*jpy_proceeds, d("309900"));
         }
         other => panic!("unexpected event: {other:?}"),
     }
@@ -62,4 +63,8 @@ fn cryptact_normalize_unsupported_action_to_diagnostic() {
     assert_eq!(got.events.len(), 0);
     assert_eq!(got.diagnostics.len(), 1);
     assert!(got.diagnostics[0].reason.contains("unsupported action"));
+}
+
+fn d(v: &str) -> Decimal {
+    Decimal::from_str(v).expect("valid decimal")
 }


### PR DESCRIPTION
## Summary
Add a first-phase Rust normalizer for Cryptact custom CSV.

## Included in phase-1
- new module: `eupholio-normalizer/src/cryptact.rs`
- parse Cryptact custom CSV headers/rows
- normalize `BUY` / `SELL` rows (JPY counter only) into `Event::{Acquire,Dispose}`
- unsupported actions routed to diagnostics instead of hard-fail
- new tests:
  - buy/sell happy-path normalization
  - unsupported action diagnostic path

## Out of scope (follow-up)
- full action coverage (`PAY`, `MINING`, `SENDFEE`, etc.)
- richer diagnostics parity with legacy Go translator behavior
- timezone configuration parity with legacy extractor
