### PR TITLE
feat(normalizer): add cryptact phase-2 PAY/MINING/SENDFEE

### DIFF
--- a/eupholio-normalizer/src/cryptact.rs
+++ b/eupholio-normalizer/src/cryptact.rs
@@ -150,10 +150,7 @@ fn map_row(
                 )));
             }
             if fee != Decimal::ZERO {
-                return Err(format!(
-                    "fee must be 0 for MINING in phase-2, got {}",
-                    fee
-                ));
+                return Err(format!("fee must be 0 for MINING in phase-2, got {}", fee));
             }
 
             let jpy_value = price_opt.map(|p| p * qty).unwrap_or(Decimal::ZERO);

--- a/eupholio-normalizer/src/cryptact.rs
+++ b/eupholio-normalizer/src/cryptact.rs
@@ -120,6 +120,61 @@ fn map_row(
     }
 
     match action.as_str() {
+        "PAY" => {
+            if fee_ccy != counter {
+                return Ok(RowOutcome::Unsupported(format!(
+                    "unsupported PAY fee currency: fee_ccy='{}', counter='{}'",
+                    sanitize_diagnostic_value(&fee_ccy),
+                    sanitize_diagnostic_value(&counter)
+                )));
+            }
+
+            let jpy_proceeds = price_opt.map(|p| p * qty).unwrap_or(Decimal::ZERO);
+            Ok(RowOutcome::Event(Event::Dispose {
+                id: format!("{}:pay", id_base),
+                asset: base_asset,
+                qty,
+                jpy_proceeds,
+                ts,
+            }))
+        }
+        "MINING" => {
+            if fee_ccy != counter {
+                return Ok(RowOutcome::Unsupported(format!(
+                    "unsupported MINING fee currency: fee_ccy='{}', counter='{}'",
+                    sanitize_diagnostic_value(&fee_ccy),
+                    sanitize_diagnostic_value(&counter)
+                )));
+            }
+
+            let jpy_value = price_opt.map(|p| p * qty).unwrap_or(Decimal::ZERO);
+            Ok(RowOutcome::Event(Event::Income {
+                id: format!("{}:mining", id_base),
+                asset: base_asset,
+                qty,
+                jpy_value,
+                ts,
+            }))
+        }
+        "SENDFEE" => {
+            if fee != Decimal::ZERO {
+                return Err(format!("fee must be 0 for SENDFEE, got {}", fee));
+            }
+            if fee_ccy != "JPY" {
+                return Ok(RowOutcome::Unsupported(format!(
+                    "unsupported SENDFEE fee currency: fee_ccy='{}'",
+                    sanitize_diagnostic_value(&fee_ccy)
+                )));
+            }
+
+            Ok(RowOutcome::Event(Event::Transfer {
+                id: format!("{}:sendfee", id_base),
+                asset: base_asset,
+                qty,
+                direction: eupholio_core::event::TransferDirection::Out,
+                ts,
+            }))
+        }
         "BUY" => {
             let price = required_positive_price(price_opt, &action)?;
             if fee_ccy != counter && fee_ccy != base_asset {

--- a/eupholio-normalizer/src/cryptact.rs
+++ b/eupholio-normalizer/src/cryptact.rs
@@ -128,6 +128,9 @@ fn map_row(
                     sanitize_diagnostic_value(&counter)
                 )));
             }
+            if fee != Decimal::ZERO {
+                return Err(format!("fee must be 0 for PAY in phase-2, got {}", fee));
+            }
 
             let jpy_proceeds = price_opt.map(|p| p * qty).unwrap_or(Decimal::ZERO);
             Ok(RowOutcome::Event(Event::Dispose {
@@ -146,6 +149,12 @@ fn map_row(
                     sanitize_diagnostic_value(&counter)
                 )));
             }
+            if fee != Decimal::ZERO {
+                return Err(format!(
+                    "fee must be 0 for MINING in phase-2, got {}",
+                    fee
+                ));
+            }
 
             let jpy_value = price_opt.map(|p| p * qty).unwrap_or(Decimal::ZERO);
             Ok(RowOutcome::Event(Event::Income {
@@ -160,10 +169,11 @@ fn map_row(
             if fee != Decimal::ZERO {
                 return Err(format!("fee must be 0 for SENDFEE, got {}", fee));
             }
-            if fee_ccy != "JPY" {
+            if fee_ccy != counter {
                 return Ok(RowOutcome::Unsupported(format!(
-                    "unsupported SENDFEE fee currency: fee_ccy='{}'",
-                    sanitize_diagnostic_value(&fee_ccy)
+                    "unsupported SENDFEE fee currency: fee_ccy='{}', counter='{}'",
+                    sanitize_diagnostic_value(&fee_ccy),
+                    sanitize_diagnostic_value(&counter)
                 )));
             }
 

--- a/eupholio-normalizer/tests/cryptact_poc.rs
+++ b/eupholio-normalizer/tests/cryptact_poc.rs
@@ -128,7 +128,7 @@ fn cryptact_normalize_ids_are_unique_per_row() {
 #[test]
 fn cryptact_normalize_unsupported_action_to_diagnostic() {
     let csv = r#"Timestamp,Action,Source,Base,Volume,Price,Counter,Fee,FeeCcy,Comment
-2026/1/2 12:00:00,MINING,bitFlyer,BTC,0.1,0,JPY,0,JPY,
+2026/1/2 12:00:00,TIP,bitFlyer,BTC,0.1,0,JPY,0,JPY,
 "#;
 
     let got = normalize_custom_csv(csv).expect("should parse");


### PR DESCRIPTION
## Summary
Add phase-2 action support to the Rust cryptact normalizer.

## Added
- `PAY` -> normalized to `Event::Dispose` (JPY proceeds from price*qty, or 0 when price omitted)
- `MINING` -> normalized to `Event::Income` (JPY value from price*qty, or 0 when price omitted)
- `SENDFEE` -> normalized to `Event::Transfer` (`Out`)

## Validation/constraints
- `counter` remains JPY-only in phase-2
- `PAY` and `MINING`: `FeeCcy` must match `Counter`
- `SENDFEE`: `Fee` must be 0, `FeeCcy` must be JPY

## Tests
- PAY mapping test
- MINING mapping test
- SENDFEE mapping test

## Notes
This keeps phase-2 incremental while preserving phase-1 review fixes (id uniqueness, header normalization, price validation for BUY/SELL, fee semantics).
