### PR TITLE
feat(normalizer): add cryptact phase-4 core action support

### DIFF
--- a/eupholio-normalizer/src/cryptact.rs
+++ b/eupholio-normalizer/src/cryptact.rs
@@ -192,7 +192,10 @@ fn map_row(
                 )));
             }
             if fee != Decimal::ZERO {
-                return Err(format!("fee must be 0 for {} in phase-4, got {}", action, fee));
+                return Err(format!(
+                    "fee must be 0 for {} in phase-4, got {}",
+                    action, fee
+                ));
             }
 
             let jpy_value = price_opt.map(|p| p * qty).unwrap_or(Decimal::ZERO);

--- a/eupholio-normalizer/src/cryptact.rs
+++ b/eupholio-normalizer/src/cryptact.rs
@@ -192,7 +192,7 @@ fn map_row(
                 )));
             }
             if fee != Decimal::ZERO {
-                return Err(format!("fee must be 0 for {}, got {}", action, fee));
+                return Err(format!("fee must be 0 for {} in phase-4, got {}", action, fee));
             }
 
             let jpy_value = price_opt.map(|p| p * qty).unwrap_or(Decimal::ZERO);

--- a/eupholio-normalizer/tests/cryptact_poc.rs
+++ b/eupholio-normalizer/tests/cryptact_poc.rs
@@ -277,7 +277,9 @@ fn cryptact_normalize_tip_to_dispose() {
     let got = normalize_custom_csv(csv).expect("should parse");
     assert_eq!(got.events.len(), 1);
     match &got.events[0] {
-        Event::Dispose { qty, jpy_proceeds, .. } => {
+        Event::Dispose {
+            qty, jpy_proceeds, ..
+        } => {
             assert_eq!(*qty, d("0.0001"));
             assert_eq!(*jpy_proceeds, d("600"));
         }

--- a/eupholio-normalizer/tests/cryptact_poc.rs
+++ b/eupholio-normalizer/tests/cryptact_poc.rs
@@ -367,9 +367,7 @@ fn cryptact_normalize_loss_and_reduce() {
     }
 
     match &got.events[1] {
-        Event::Transfer {
-            qty, direction, ..
-        } => {
+        Event::Transfer { qty, direction, .. } => {
             assert_eq!(*qty, d("1"));
             assert_eq!(*direction, eupholio_core::event::TransferDirection::Out);
         }


### PR DESCRIPTION
## Summary
Add phase-4 cryptact action support in Rust normalizer.

## Added actions
- BONUS -> `Event::Income`
- LENDING -> `Event::Income`
- STAKING -> `Event::Income`
- TIP -> `Event::Dispose`
- LOSS -> `Event::Dispose` (0 proceeds)
- REDUCE -> `Event::Transfer` (Out)

## Validation
- requires `FeeCcy == Counter` for phase-4 actions
- requires `Fee == 0` for phase-4 actions

## Tests
- bonus/lending/staking mapping
- tip mapping
- loss/reduce mapping
- unsupported action case updated to `RETURN`

## Notes
This intentionally keeps an incremental mapping strategy with current `Event` domain types.
