### PR TITLE
feat(normalizer): add cryptact phase-5 action support

### DIFF
--- a/eupholio-normalizer/src/cryptact.rs
+++ b/eupholio-normalizer/src/cryptact.rs
@@ -303,10 +303,13 @@ fn map_row(
                 ));
             }
 
-            let direction = if action == "RECOVER" || action == "BORROW" {
-                eupholio_core::event::TransferDirection::In
-            } else {
-                eupholio_core::event::TransferDirection::Out
+            let direction = match action {
+                "RECOVER" | "BORROW" => eupholio_core::event::TransferDirection::In,
+                "RETURN" => eupholio_core::event::TransferDirection::Out,
+                other => unreachable!(
+                    "unexpected action in RECOVER/BORROW/RETURN arm: {}",
+                    other
+                ),
             };
 
             Ok(RowOutcome::Event(Event::Transfer {

--- a/eupholio-normalizer/src/cryptact.rs
+++ b/eupholio-normalizer/src/cryptact.rs
@@ -297,7 +297,10 @@ fn map_row(
                 )));
             }
             if fee != Decimal::ZERO {
-                return Err(format!("fee must be 0 for {} in phase-5, got {}", action, fee));
+                return Err(format!(
+                    "fee must be 0 for {} in phase-5, got {}",
+                    action, fee
+                ));
             }
 
             let direction = if action == "RECOVER" || action == "BORROW" {

--- a/eupholio-normalizer/src/cryptact.rs
+++ b/eupholio-normalizer/src/cryptact.rs
@@ -303,13 +303,10 @@ fn map_row(
                 ));
             }
 
-            let direction = match action {
+            let direction = match action.as_str() {
                 "RECOVER" | "BORROW" => eupholio_core::event::TransferDirection::In,
                 "RETURN" => eupholio_core::event::TransferDirection::Out,
-                other => unreachable!(
-                    "unexpected action in RECOVER/BORROW/RETURN arm: {}",
-                    other
-                ),
+                other => unreachable!("unexpected action in RECOVER/BORROW/RETURN arm: {}", other),
             };
 
             Ok(RowOutcome::Event(Event::Transfer {

--- a/eupholio-normalizer/src/cryptact.rs
+++ b/eupholio-normalizer/src/cryptact.rs
@@ -268,26 +268,7 @@ fn map_row(
                 ts,
             }))
         }
-        "LEND" => {
-            if fee_ccy != counter {
-                return Ok(RowOutcome::Unsupported(format!(
-                    "unsupported LEND fee currency: fee_ccy='{}', counter='{}'",
-                    sanitize_diagnostic_value(&fee_ccy),
-                    sanitize_diagnostic_value(&counter)
-                )));
-            }
-            if fee != Decimal::ZERO {
-                return Err(format!("fee must be 0 for LEND in phase-5, got {}", fee));
-            }
-            Ok(RowOutcome::Event(Event::Transfer {
-                id: format!("{}:lend", id_base),
-                asset: base_asset,
-                qty,
-                direction: eupholio_core::event::TransferDirection::Out,
-                ts,
-            }))
-        }
-        "RECOVER" | "BORROW" | "RETURN" => {
+        "RECOVER" | "BORROW" | "LEND" | "RETURN" => {
             if fee_ccy != counter {
                 return Ok(RowOutcome::Unsupported(format!(
                     "unsupported {} fee currency: fee_ccy='{}', counter='{}'",
@@ -305,8 +286,11 @@ fn map_row(
 
             let direction = match action.as_str() {
                 "RECOVER" | "BORROW" => eupholio_core::event::TransferDirection::In,
-                "RETURN" => eupholio_core::event::TransferDirection::Out,
-                other => unreachable!("unexpected action in RECOVER/BORROW/RETURN arm: {}", other),
+                "LEND" | "RETURN" => eupholio_core::event::TransferDirection::Out,
+                other => unreachable!(
+                    "unexpected action in RECOVER/BORROW/LEND/RETURN arm: {}",
+                    other
+                ),
             };
 
             Ok(RowOutcome::Event(Event::Transfer {

--- a/eupholio-normalizer/tests/cryptact_poc.rs
+++ b/eupholio-normalizer/tests/cryptact_poc.rs
@@ -128,7 +128,7 @@ fn cryptact_normalize_ids_are_unique_per_row() {
 #[test]
 fn cryptact_normalize_unsupported_action_to_diagnostic() {
     let csv = r#"Timestamp,Action,Source,Base,Volume,Price,Counter,Fee,FeeCcy,Comment
-2026/1/2 12:00:00,RETURN,bitFlyer,BTC,0.1,0,JPY,0,JPY,
+2026/1/2 12:00:00,AIRDROP,bitFlyer,BTC,0.1,0,JPY,0,JPY,
 "#;
 
     let got = normalize_custom_csv(csv).expect("should parse");
@@ -426,7 +426,7 @@ fn cryptact_normalize_phase5_lend_recover_borrow_return_defifee() {
 #[test]
 fn cryptact_normalize_phase5_cash_to_diagnostic() {
     let csv = r#"Timestamp,Action,Source,Base,Volume,Price,Counter,Fee,FeeCcy,Comment
-2026/1/2 12:00:00,CASH,manual,JPY,0,0,JPY,2000,JPY,
+2026/1/2 12:00:00,CASH,manual,JPY,1,0,JPY,2000,JPY,
 "#;
 
     let got = normalize_custom_csv(csv).expect("should parse");

--- a/eupholio-normalizer/tests/cryptact_poc.rs
+++ b/eupholio-normalizer/tests/cryptact_poc.rs
@@ -488,8 +488,8 @@ fn cryptact_normalize_phase5_nonzero_fee_errors() {
             action
         );
 
-        let err = normalize_custom_csv(&csv)
-            .expect_err(&format!("non-zero {} fee should fail", action));
+        let err =
+            normalize_custom_csv(&csv).expect_err(&format!("non-zero {} fee should fail", action));
         assert!(
             err.contains(&format!("fee must be 0 for {} in phase-5", action)),
             "unexpected error for {action}: {err}"

--- a/eupholio-normalizer/tests/cryptact_poc.rs
+++ b/eupholio-normalizer/tests/cryptact_poc.rs
@@ -458,12 +458,19 @@ fn cryptact_normalize_phase5_lend_recover_borrow_return_defifee() {
 
 #[test]
 fn cryptact_normalize_phase5_nonzero_fee_errors() {
-    let csv = r#"Timestamp,Action,Source,Base,Volume,Price,Counter,Fee,FeeCcy,Comment
-2026/1/2 12:00:00,LEND,bitFlyer,BTC,0.1,,JPY,1,JPY,
-"#;
+    for action in ["LEND", "RECOVER", "BORROW", "RETURN", "DEFIFEE"] {
+        let csv = format!(
+            "Timestamp,Action,Source,Base,Volume,Price,Counter,Fee,FeeCcy,Comment\n2026/1/2 12:00:00,{},bitFlyer,BTC,0.1,,JPY,1,JPY,\n",
+            action
+        );
 
-    let err = normalize_custom_csv(csv).expect_err("non-zero phase-5 fee should fail");
-    assert!(err.contains("fee must be 0 for LEND in phase-5"));
+        let err = normalize_custom_csv(&csv)
+            .expect_err(&format!("non-zero {} fee should fail", action));
+        assert!(
+            err.contains(&format!("fee must be 0 for {} in phase-5", action)),
+            "unexpected error for {action}: {err}"
+        );
+    }
 }
 
 #[test]

--- a/eupholio-normalizer/tests/cryptact_poc.rs
+++ b/eupholio-normalizer/tests/cryptact_poc.rs
@@ -457,6 +457,30 @@ fn cryptact_normalize_phase5_lend_recover_borrow_return_defifee() {
 }
 
 #[test]
+fn cryptact_normalize_phase5_non_jpy_fee_ccy_to_diagnostics() {
+    for action in ["LEND", "RECOVER", "BORROW", "RETURN", "DEFIFEE"] {
+        let csv = format!(
+            "Timestamp,Action,Source,Base,Volume,Price,Counter,Fee,FeeCcy,Comment\n2026/1/2 12:00:00,{},bitFlyer,BTC,0.1,,JPY,0,BTC,\n",
+            action
+        );
+
+        let got = normalize_custom_csv(&csv).expect("should parse");
+        assert_eq!(
+            got.events.len(),
+            0,
+            "non-JPY fee_ccy for {} should not produce events",
+            action
+        );
+        assert_eq!(
+            got.diagnostics.len(),
+            1,
+            "non-JPY fee_ccy for {} should produce a diagnostic",
+            action
+        );
+    }
+}
+
+#[test]
 fn cryptact_normalize_phase5_nonzero_fee_errors() {
     for action in ["LEND", "RECOVER", "BORROW", "RETURN", "DEFIFEE"] {
         let csv = format!(


### PR DESCRIPTION
## Summary
Add phase-5 cryptact action support in Rust normalizer.

## Added actions
- LEND -> Transfer(Out)
- RECOVER -> Transfer(In)
- BORROW -> Transfer(In)
- RETURN -> Transfer(Out)
- DEFIFEE -> Dispose (0 proceeds)
- CASH -> diagnostic (not yet supported in current Event model)

## Validation
- phase-5 actions require `counter == JPY` (existing global phase behavior)
- phase-5 actions require `FeeCcy == Counter`
- phase-5 actions require `Fee == 0`

## Tests
- phase-5 happy path for LEND/RECOVER/BORROW/RETURN/DEFIFEE
- CASH diagnostic path

## Notes
CASH requires a richer event model for fiat-only accounting treatment and is intentionally diagnostic in this phase.
